### PR TITLE
ci: add workflow to sync to Gitee repo

### DIFF
--- a/.github/workflows/sync2gitee.yml
+++ b/.github/workflows/sync2gitee.yml
@@ -1,0 +1,16 @@
+name: sync2gitee
+on: [push]
+
+jobs:
+  repo-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mirror the Github organization repos to Gitee.
+        uses: Yikun/hub-mirror-action@master
+        with:
+          src: 'github/1Panel-dev'
+          dst: 'gitee/fit2cloud-xlab'
+          dst_key: ${{ secrets.GITEE_PRIVATE_KEY }}
+          dst_token:  ${{ secrets.GITEE_TOKEN }}
+          static_list: "1Panel"
+          force_update: true


### PR DESCRIPTION
#### What this PR does / why we need it?

同步 1Panle 仓库到 Gitee 中 https://gitee.com/fit2cloud-xlab/1Panel。

#### Summary of your change

增加 sync2gitee action。

PR 合并后还需要在仓库配置中增加如下 secrets：
- GITEE_PRIVATE_KEY：有目标仓库 push 权限的 Gitee 账号的 SSH private key；
- GITEE_TOKEN：有目标组织创建仓库权限的 Gitee 账号 token，用于自动创建不存在的组织。

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.