### PR TITLE
fix: 修复前端开发时后端接口代理无法正常连接 WebSocket 的问题

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -40,6 +40,7 @@ export default defineConfig(({ mode }: ConfigEnv): UserConfig => {
                 '/api/v1': {
                     target: 'http://localhost:9999/',
                     changeOrigin: true,
+                    ws: true,
                 },
             },
         },


### PR DESCRIPTION
不确定开发团队是否有碰到这个问题，我这边将后端接口代理到自己服务器时， WebSocket 无法正常建立连接，需要添加参数才行。

另外，官网的开发文档可以做一些补充，如只需要调试前端开发环境时，可以将代理指向在线服务器的后端接口，而不是在本地起一个后端。