### PR TITLE
fix: 获取网站日志时，先检查一下日志文件大小，超过10M时直接报错

### DIFF
--- a/backend/app/service/website.go
+++ b/backend/app/service/website.go
@@ -863,7 +863,7 @@ func (w WebsiteService) OpWebsiteLog(req request.WebsiteLogReq) (*response.Websi
 			return nil, buserr.New(constant.ErrFileTooLarge)
 		}
 		fileInfo.Size()
-		content, err := os.ReadFile(path.Join(sitePath, "log", req.LogType))
+		content, err := os.ReadFile(filePath)
 		if err != nil {
 			return nil, err
 		}

--- a/backend/app/service/website.go
+++ b/backend/app/service/website.go
@@ -854,6 +854,15 @@ func (w WebsiteService) OpWebsiteLog(req request.WebsiteLogReq) (*response.Websi
 				return res, nil
 			}
 		}
+		filePath := path.Join(sitePath, "log", req.LogType)
+		fileInfo, err := os.Stat(filePath)
+		if err != nil {
+			return nil, err
+		}
+		if fileInfo.Size() > 10*1024*1024 {
+			return nil, buserr.New(constant.ErrFileTooLarge)
+		}
+		fileInfo.Size()
 		content, err := os.ReadFile(path.Join(sitePath, "log", req.LogType))
 		if err != nil {
 			return nil, err

--- a/backend/constant/errs.go
+++ b/backend/constant/errs.go
@@ -89,6 +89,7 @@ var (
 	ErrLinkPathNotFound = "ErrLinkPathNotFound"
 	ErrFileIsExit       = "ErrFileIsExit"
 	ErrFileUpload       = "ErrFileUpload"
+	ErrFileTooLarge     = "ErrFileTooLarge"
 )
 
 // mysql


### PR DESCRIPTION
#### What this PR does / why we need it?

修复网站日志文件较大时，在界面上查看日志会导致系统短时间卡住的问题

相关Issue https://github.com/1Panel-dev/1Panel/issues/495
该提交可优化这个Issue的问题

#### Summary of your change

在获取文件内容之前，通过os.Stat获取文件的信息，并对文件大小进行判断，如果过大（目前是>10MB），则抛出错误中止流程

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.