### PR TITLE
fix: 解决网站的默认文档不能设置为子目录的文件的问题

### DIFF
--- a/frontend/src/global/form-rules.ts
+++ b/frontend/src/global/form-rules.ts
@@ -244,7 +244,7 @@ const checkDoc = (rule: any, value: any, callback: any) => {
     if (value === '' || typeof value === 'undefined' || value == null) {
         callback(new Error(i18n.global.t('commons.rule.nginxDoc')));
     } else {
-        const reg = /^[A-Za-z0-9\n.]+$/;
+        const reg = /^[A-Za-z0-9\n./]+$/;
         if (!reg.test(value) && value !== '') {
             callback(new Error(i18n.global.t('commons.rule.nginxDoc')));
         } else {


### PR DESCRIPTION
Refs https://github.com/1Panel-dev/1Panel/issues/720