### PR TITLE
feat: ssh登录日志增加一键屏蔽ip #1309

### DIFF
--- a/frontend/src/views/host/ssh/log/log.vue
+++ b/frontend/src/views/host/ssh/log/log.vue
@@ -25,6 +25,9 @@
                         <el-tag type="danger" size="large" style="margin-left: 5px">
                             {{ $t('commons.status.failed') }}： {{ faliedCount }}
                         </el-tag>
+                        <el-button plain @click="onDeny" :disabled="selects.length === 0" style="margin-left: 5px">
+                            {{ $t('firewall.deny') }}
+                        </el-button>
                     </el-col>
                     <el-col :xs="24" :sm="8" :md="8" :lg="8" :xl="8">
                         <TableSetting @search="search()" />
@@ -44,7 +47,13 @@
             </template>
 
             <template #main>
-                <ComplexTable :pagination-config="paginationConfig" :data="data" @search="search">
+                <ComplexTable
+                    :pagination-config="paginationConfig"
+                    v-model:selects="selects"
+                    :data="data"
+                    @search="search"
+                >
+                    <el-table-column type="selection" :selectable="selectable" fix />
                     <el-table-column min-width="80" :label="$t('logs.loginIP')" prop="address" />
                     <el-table-column min-width="60" :label="$t('ssh.belong')" prop="area" />
                     <el-table-column min-width="60" :label="$t('firewall.port')" prop="port" />
@@ -83,6 +92,9 @@ import TableSetting from '@/components/table-setting/index.vue';
 import { dateFormat } from '@/utils/util';
 import { onMounted, reactive, ref } from '@vue/runtime-core';
 import { loadSSHLogs } from '@/api/modules/host';
+import { operateIPRule } from '@/api/modules/host';
+import { MsgSuccess } from '@/utils/message';
+import i18n from '@/lang';
 
 const loading = ref();
 const data = ref();
@@ -95,6 +107,28 @@ const searchInfo = ref();
 const searchStatus = ref('All');
 const successfulCount = ref(0);
 const faliedCount = ref(0);
+const selects = ref<any>([]);
+
+function selectable(row: any): boolean {
+    return row.address !== '127.0.0.1' && row.address !== '::1';
+}
+
+function select2address(): string {
+    let res = [];
+    selects.value.forEach((item: any) => {
+        if (!res.includes(item.address)) res.push(item.address);
+    });
+    return res.join(',');
+}
+
+const onDeny = async () => {
+    let address = select2address();
+    if (!address) return;
+    await operateIPRule({ operation: 'add', address: address, strategy: 'drop' }).then(() => {
+        MsgSuccess(i18n.global.t('commons.msg.operationSuccess'));
+        search();
+    });
+};
 
 const search = async () => {
     let params = {


### PR DESCRIPTION
feat: ssh登录日志增加一键屏蔽ip #1309 

只改了前端，在前端调用了添加屏蔽IP的接口

#### 效果
![Snipaste_2023-06-13_00-11-42](https://github.com/1Panel-dev/1Panel/assets/24670171/943e1c09-5a62-4a00-87fe-61b5898cda92)
