### PR TITLE
fix: 修复无法读取ssh成功日志

### DIFF
--- a/backend/app/service/ssh.go
+++ b/backend/app/service/ssh.go
@@ -248,7 +248,7 @@ func (u *SSHService) LoadLog(req dto.SearchSSHLog) (*dto.SSHLog, error) {
 				data.Logs = append(data.Logs, dataItem...)
 			}
 		}
-		commandItem := fmt.Sprintf("cat %s | grep Accepted %s", fileList[i], command)
+		commandItem := fmt.Sprintf("cat %s | grep -a Accepted %s", fileList[i], command)
 		dataItem := loadSuccessDatas(commandItem)
 		data.TotalCount += len(dataItem)
 		if req.Status != constant.StatusFailed {


### PR DESCRIPTION

#### What this PR does / why we need it?
一些情况下，log文件被识别成二进制格式，导致无法读取ssh成功日志。加-a参数，强制按文本方式读取。
我看了一下，失败日志已经加上了 -a，成功日志可能是忘记加了。

#### Summary of your change
grep Accepted 改成 grep -a Accepted
