### PR TITLE
fix: 修复ssh日志为空时不渲染的问题

### DIFF
--- a/frontend/src/views/host/ssh/log/log.vue
+++ b/frontend/src/views/host/ssh/log/log.vue
@@ -141,7 +141,7 @@ const search = async () => {
     await loadSSHLogs(params)
         .then((res) => {
             loading.value = false;
-            data.value = res.data.logs || [];
+            data.value = res.data?.logs || [];
             faliedCount.value = res.data.failedCount;
             successfulCount.value = res.data.successfulCount;
             if (searchStatus.value === 'Success') {


### PR DESCRIPTION
#### What this PR does / why we need it?
当后端获取到的ssh日志为空时，传递到前端的data = null
`data.value = res.data.logs || [];`
这时候，运行到 res.data.logs时，会发生错误，导致data.value并不会更新到视图。
改成
`data.value = res.data?.logs || [];`
就可以了