### PR TITLE
fix: 修正容器重启规则翻译错误

### DIFF
--- a/frontend/src/lang/modules/tw.ts
+++ b/frontend/src/lang/modules/tw.ts
@@ -531,7 +531,7 @@ const message = {
         env: '環境變量',
         restartPolicy: '重啟規則',
         always: '一直重啟',
-        unlessStopped: '關閉後重啟',
+        unlessStopped: '未手動停止則重啟',
         onFailure: '失敗後重啟（默認重啟 5 次）',
         no: '不重啟',
 

--- a/frontend/src/lang/modules/zh.ts
+++ b/frontend/src/lang/modules/zh.ts
@@ -531,7 +531,7 @@ const message = {
         env: '环境变量',
         restartPolicy: '重启规则',
         always: '一直重启',
-        unlessStopped: '关闭后重启',
+        unlessStopped: '未手动停止则重启',
         onFailure: '失败后重启（默认重启 5 次）',
         no: '不重启',
 


### PR DESCRIPTION
#### What this PR does / why we need it?
fix: Docker容器的重启策略中的`unless-stopped`，意为在容器退出时总是重启容器，但是不考虑在Docker守护进程启动时就已经停止了的容器。据此修正翻译错误。
#### Summary of your change
修改前：
![image](https://github.com/1Panel-dev/1Panel/assets/81958172/e529ff97-cae9-491c-a965-fdf94defea3d)

修改后：
![image](https://github.com/1Panel-dev/1Panel/assets/81958172/30865426-ab40-43a7-8fb6-77d3bd59dfe7)

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.