### PR TITLE
fix: 修复压缩包解压时可能的由于父目录不存在导致的解压失败的问题

### DIFF
--- a/backend/utils/files/file_op.go
+++ b/backend/utils/files/file_op.go
@@ -518,6 +518,13 @@ func (f FileOp) Decompress(srcFile string, dst string, cType CompressType) error
 				return err
 			}
 			return nil
+		} else {
+			parentDir := path.Dir(filePath)
+			if !f.Stat(parentDir) {
+				if err := f.Fs.MkdirAll(parentDir, info.Mode()); err != nil {
+					return err
+				}
+			}
 		}
 		fr, err := archFile.Open()
 		if err != nil {


### PR DESCRIPTION
#### What this PR does / why we need it?
修复解压压缩包时可能出现的文件父目录未创建导致的解压失败的问题 #2098 
#### Summary of your change
在handler中filePath为文件时增加一层校验，校验父目录是否存在，不存在则MakedirAll
#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.