### PR TITLE
fix: 解决文件名带空格导致的设置权限失败的问题

### DIFF
--- a/backend/app/service/website_utils.go
+++ b/backend/app/service/website_utils.go
@@ -633,13 +633,9 @@ func checkIsLinkApp(website model.Website) bool {
 }
 
 func chownRootDir(path string) error {
-	_, err := cmd.ExecWithTimeOut(fmt.Sprintf("chown -R 1000:1000 %s", path), 1*time.Second)
+	_, err := cmd.ExecWithTimeOut(fmt.Sprintf(`chown -R 1000:1000 "%s"`, path), 1*time.Second)
 	if err != nil {
 		return err
 	}
-	return nil
-}
-
-func checkWebsiteDirPermission(path string) error {
 	return nil
 }

--- a/backend/utils/files/file_op.go
+++ b/backend/utils/files/file_op.go
@@ -125,9 +125,9 @@ func (f FileOp) Chown(dst string, uid int, gid int) error {
 }
 
 func (f FileOp) ChownR(dst string, uid string, gid string, sub bool) error {
-	cmdStr := fmt.Sprintf("chown %s:%s %s", uid, gid, dst)
+	cmdStr := fmt.Sprintf(`chown %s:%s "%s"`, uid, gid, dst)
 	if sub {
-		cmdStr = fmt.Sprintf("chown -R %s:%s %s", uid, gid, dst)
+		cmdStr = fmt.Sprintf(`chown -R %s:%s "%s"`, uid, gid, dst)
 	}
 	if cmd.HasNoPasswordSudo() {
 		cmdStr = fmt.Sprintf("sudo %s", cmdStr)
@@ -142,7 +142,7 @@ func (f FileOp) ChownR(dst string, uid string, gid string, sub bool) error {
 }
 
 func (f FileOp) ChmodR(dst string, mode int64) error {
-	cmdStr := fmt.Sprintf("chmod -R %v %s", fmt.Sprintf("%04o", mode), dst)
+	cmdStr := fmt.Sprintf(`chmod -R %v "%s"`, fmt.Sprintf("%04o", mode), dst)
 	if cmd.HasNoPasswordSudo() {
 		cmdStr = fmt.Sprintf("sudo %s", cmdStr)
 	}


### PR DESCRIPTION
Refs https://github.com/1Panel-dev/1Panel/issues/2149