### PR TITLE
fix: 解决反向代理网站在 firefox 浏览器打开失败的问题

### DIFF
--- a/cmd/server/nginx_conf/ssl.conf
+++ b/cmd/server/nginx_conf/ssl.conf
@@ -8,3 +8,5 @@ ssl_session_timeout 10m;
 add_header Strict-Transport-Security "max-age=31536000";
 error_page 497  https://$host$request_uri;
 proxy_set_header X-Forwarded-Proto https;
+ssl_stapling on;
+ssl_stapling_verify on;


### PR DESCRIPTION
Refs https://github.com/1Panel-dev/1Panel/issues/1465