### PR TITLE
fix: 解决 UFW 防火墙规则为空时插入规则失败的问题

### DIFF
--- a/backend/utils/firewall/client/ufw.go
+++ b/backend/utils/firewall/client/ufw.go
@@ -183,6 +183,13 @@ func (f *Ufw) RichRules(rule FireInfo, operation string) error {
 
 	stdout, err := cmd.Exec(ruleStr)
 	if err != nil {
+		if strings.Contains(stdout, "ERROR: Invalid position") {
+			stdout, err := cmd.Exec(strings.ReplaceAll(ruleStr, "insert 1 ", ""))
+			if err != nil {
+				return fmt.Errorf("%s rich rules (%s), failed, err: %s", operation, ruleStr, stdout)
+			}
+			return nil
+		}
 		return fmt.Errorf("%s rich rules (%s), failed, err: %s", operation, ruleStr, stdout)
 	}
 	return nil


### PR DESCRIPTION
Refs #2794 