### PR TITLE
feat:增加控制台静态资源/assets/浏览器缓存

### DIFF
--- a/backend/init/router/router.go
+++ b/backend/init/router/router.go
@@ -4,6 +4,7 @@ import (
 	"github.com/gin-contrib/gzip"
 	"html/template"
 	"net/http"
+	"strings"
 
 	"github.com/1Panel-dev/1Panel/backend/global"
 	"github.com/1Panel-dev/1Panel/backend/i18n"
@@ -19,6 +20,12 @@ import (
 
 func setWebStatic(rootRouter *gin.RouterGroup) {
 	rootRouter.StaticFS("/public", http.FS(web.Favicon))
+	rootRouter.Use(func(c *gin.Context) {
+		if strings.HasPrefix(c.Request.URL.Path, "/assets") {
+			c.Header("Cache-Control", "max-age=31536000")
+		}
+		c.Next()
+	})
 	rootRouter.GET("/assets/*filepath", func(c *gin.Context) {
 		staticServer := http.FileServer(http.FS(web.Assets))
 		staticServer.ServeHTTP(c.Writer, c.Request)

--- a/backend/init/router/router.go
+++ b/backend/init/router/router.go
@@ -21,7 +21,7 @@ import (
 func setWebStatic(rootRouter *gin.RouterGroup) {
 	rootRouter.StaticFS("/public", http.FS(web.Favicon))
 	rootRouter.Use(func(c *gin.Context) {
-		if strings.HasPrefix(c.Request.URL.Path, "/assets") {
+		if strings.HasPrefix(c.Request.URL.Path, "/assets/") {
 			c.Header("Cache-Control", "max-age=31536000")
 		}
 		c.Next()


### PR DESCRIPTION
#### What this PR does / why we need it?
当前操作控制台(每点击一个不同的页面)或刷新后,都需要从服务器加载静态资源且没有缓存,在网络差的情况下访问特别慢

#### Summary of your change
给静态资源增加浏览器缓存时间
#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.