### PR TITLE
fix: 本地数据库备份命令增加 --default-character-set 参数 与备份还原的编码保持一致

### DIFF
--- a/backend/utils/mysql/client/local.go
+++ b/backend/utils/mysql/client/local.go
@@ -220,7 +220,7 @@ func (r *Local) Backup(info BackupInfo) error {
 	}
 	outfile, _ := os.OpenFile(path.Join(info.TargetDir, info.FileName), os.O_RDWR|os.O_CREATE, 0755)
 	global.LOG.Infof("start to mysqldump | gzip > %s.gzip", info.TargetDir+"/"+info.FileName)
-	cmd := exec.Command("docker", "exec", r.ContainerName, "mysqldump", "-uroot", "-p"+r.Password, info.Name)
+	cmd := exec.Command("docker", "exec", r.ContainerName, "mysqldump", "-uroot", "-p"+r.Password, "--default-character-set="+info.Format, info.Name)
 	gzipCmd := exec.Command("gzip", "-cf")
 	gzipCmd.Stdin, _ = cmd.StdoutPipe()
 	gzipCmd.Stdout = outfile


### PR DESCRIPTION
确保在导出数据时，使用与导入数据时相同的字符集，以避免字符集转换问题和数据损坏 (如数据中包含emoji等特殊字符) 

Refs #2813 