### PR TITLE
Update vite.config.ts

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -84,6 +84,7 @@ export default defineConfig(({ mode }: ConfigEnv): UserConfig => {
             outDir: '../cmd/server/web',
             minify: 'esbuild',
             rollupOptions: {
+								external: ['codemirror'],
                 output: {
                     chunkFileNames: 'assets/js/[name]-[hash].js',
                     entryFileNames: 'assets/js/[name]-[hash].js',


### PR DESCRIPTION
fix  codemirror error

#### What this PR does / why we need it?
[vite]: Rollup failed to resolve import "codemirror" from "node_modules/vue-codemirror/dist/vue-codemirror.esm.js".
This is most likely unintended because it can break your application at runtime.

#### Summary of your change
 this module explicitly add it to
`build.rollupOptions.external`
