### PR TITLE
fix: fix typo for i18n-en

### DIFF
--- a/frontend/src/lang/modules/en.ts
+++ b/frontend/src/lang/modules/en.ts
@@ -1553,7 +1553,7 @@ const message = {
         less1Minute: 'Less than 1 minute',
         appOfficeWebsite: 'Office website',
         github: 'Github',
-        document: 'Cocument',
+        document: 'Document',
         updatePrompt: 'The current application is the latest version',
         installPrompt: 'No apps installed yet',
         updateHelper: 'Updating parameters may cause the application to fail to start, please operate with caution',


### PR DESCRIPTION
#### What this PR does / why we need it?

fix an i18n typo.
#### Summary of your change

Here:

![image](https://github.com/1Panel-dev/1Panel/assets/6964737/00b01884-4fb8-4e96-ae42-226c38588753)


#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.