### PR TITLE
pref: 使获取文件Size时，若文件为文件夹，则递归获取其子文件size(#3934)

### DIFF
--- a/backend/utils/files/fileinfo.go
+++ b/backend/utils/files/fileinfo.go
@@ -299,11 +299,14 @@ func (f *FileInfo) listChildren(option FileOption) error {
 				isInvalidLink = true
 			}
 		}
-
+		size, err := CalFileSize(f.Fs, fPath)
+		if err != nil {
+			return err
+		}
 		file := &FileInfo{
 			Fs:        f.Fs,
 			Name:      name,
-			Size:      df.Size(),
+			Size:      size,
 			ModTime:   df.ModTime(),
 			FileMode:  df.Mode(),
 			IsDir:     df.IsDir(),

--- a/backend/utils/files/fileinfo.go
+++ b/backend/utils/files/fileinfo.go
@@ -76,6 +76,7 @@ func NewFileInfo(op FileOption) (*FileInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	file := &FileInfo{
 		Fs:        appFs,
 		Path:      op.Path,


### PR DESCRIPTION
#### What this PR does / why we need it?

对问题 #3934 优化，避免文件夹size很小的情况

#### Summary of your change

使获取文件Size时，若文件为文件夹，则递归获取其子文件size

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.