### PR TITLE
perf: 应用商店的应用介绍样式

### DIFF
--- a/frontend/src/views/app-store/apps/index.vue
+++ b/frontend/src/views/app-store/apps/index.vue
@@ -361,15 +361,13 @@ onMounted(() => {
 
         .app-desc {
             margin-top: 8px;
-            overflow: hidden;
-            display: -webkit-box;
-            -webkit-line-clamp: 2;
-            -webkit-box-orient: vertical;
-
-            text-overflow: ellipsis;
             height: 43px;
-
             .desc {
+                overflow: hidden;
+                display: -webkit-box;
+                -webkit-line-clamp: 2;
+                -webkit-box-orient: vertical;
+                text-overflow: ellipsis;
                 font-size: 14px;
                 color: var(--el-text-color-regular);
             }


### PR DESCRIPTION
#### What this PR does / why we need it?

在 Windows 平台上，后台页面的应用商店列表中，应用介绍的文字省略样式存在问题

- before:

  ![image](https://github.com/1Panel-dev/1Panel/assets/21162238/08bbd42e-c3c5-4633-bae9-3abd3b1087be)

#### Summary of your change

1. [perf: 应用商店的应用介绍样式](https://github.com/1Panel-dev/1Panel/commit/2de4644617ed774806fa9bfaf7658d8df3248fc3)

- after:
  
  ![image](https://github.com/1Panel-dev/1Panel/assets/21162238/dccdda39-c29b-4b77-abf8-69d40c89baee)
#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.