### PR TITLE
fix: 解决重复访问容器内部时，终端显示宽度异常的问题

### DIFF
--- a/frontend/src/views/container/container/terminal/index.vue
+++ b/frontend/src/views/container/container/terminal/index.vue
@@ -44,13 +44,17 @@
                 {{ $t('commons.button.conn') }}
             </el-button>
             <el-button v-else @click="onClose()">{{ $t('commons.button.disconn') }}</el-button>
-            <Terminal style="height: calc(100vh - 302px)" ref="terminalRef"></Terminal>
+            <Terminal
+                style="height: calc(100vh - 302px); margin-top: 18px"
+                ref="terminalRef"
+                v-if="terminalOpen"
+            ></Terminal>
         </el-form>
     </el-drawer>
 </template>
 
 <script lang="ts" setup>
-import { reactive, ref } from 'vue';
+import { reactive, ref, nextTick } from 'vue';
 import { ElForm, FormInstance } from 'element-plus';
 import { Rules } from '@/global/form-rules';
 import Terminal from '@/components/terminal/index.vue';
@@ -91,6 +95,7 @@ const initTerm = (formEl: FormInstance | undefined) => {
     formEl.validate(async (valid) => {
         if (!valid) return;
         terminalOpen.value = true;
+        await nextTick();
         terminalRef.value!.acceptParams({
             endpoint: '/api/v1/containers/exec',
             args: `containerid=${form.containerID}&user=${form.user}&command=${form.command}`,


### PR DESCRIPTION
#### What this PR does / why we need it?

ref #3995 

#### Summary of your change

1. 再重新连接终端时，终端组件将重新渲染
2. 优化了下终端组件与上方按钮的距离

https://github.com/1Panel-dev/1Panel/assets/21162238/a66699e1-2353-4827-9b74-b3eb28adbc2a


#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.