### PR TITLE
fix: 解决命令注入waf被绕过的问题

### DIFF
--- a/backend/utils/cmd/cmd.go
+++ b/backend/utils/cmd/cmd.go
@@ -177,7 +177,8 @@ func CheckIllegal(args ...string) bool {
 	for _, arg := range args {
 		if strings.Contains(arg, "&") || strings.Contains(arg, "|") || strings.Contains(arg, ";") ||
 			strings.Contains(arg, "$") || strings.Contains(arg, "'") || strings.Contains(arg, "`") ||
-			strings.Contains(arg, "(") || strings.Contains(arg, ")") || strings.Contains(arg, "\"") {
+			strings.Contains(arg, "(") || strings.Contains(arg, ")") || strings.Contains(arg, "\"") ||
+			strings.Contains(arg, "\n") || strings.Contains(arg, "\r") {
 			return true
 		}
 	}


### PR DESCRIPTION
author: https://github.com/l1nyz-tel/

---

`backend/router/ro_toolbox.go#InitRouter` 中的一处 `/device/update/swap` 路由对应的函数 `baseApi.UpdateDeviceSwap` 存在命令注入

![](https://pic.l1nyz-tel.cc/202403082132702.png)

```go
func (b *BaseApi) UpdateDeviceSwap(c *gin.Context) {
	var req dto.SwapHelper
	if err := helper.CheckBindAndValidate(&req, c); err != nil {
		return
	}
	if err := deviceService.UpdateSwap(req); err != nil {
		helper.ErrorWithDetail(c, constant.CodeErrInternalServer, constant.ErrTypeInternalServer, err)
		return
	}

	helper.SuccessWithData(c, nil)
}
```

`UpdateSwap` 函数中调用了 `cmd.Execf` 有命令拼接，可以执行命令的，不过有一个 `CheckIllegal` 需要绕过

```go
func (u *DeviceService) UpdateSwap(req dto.SwapHelper) error {
	if cmd.CheckIllegal(req.Path) {
		return buserr.New(constant.ErrCmdIllegal)
	}
	if !req.IsNew {
		std, err := cmd.Execf("%s swapoff %s", cmd.SudoHandleCmd(), req.Path)
		if err != nil {
			return fmt.Errorf("handle swapoff %s failed, err: %s", req.Path, std)
		}
	}
    ......
```

查看 `CheckIllegal` 代码，直接是对关键字符进行判断的

**绕过方式: `\n` 换行执行一条新的命令**

```go
func CheckIllegal(args ...string) bool {
	if args == nil {
		return false
	}
	for _, arg := range args {
		if strings.Contains(arg, "&") || strings.Contains(arg, "|") || strings.Contains(arg, ";") ||
			strings.Contains(arg, "$") || strings.Contains(arg, "'") || strings.Contains(arg, "`") ||
			strings.Contains(arg, "(") || strings.Contains(arg, ")") || strings.Contains(arg, "\"") {
			return true
		}
	}
	return false
}
```

数据包如下  
==在 `\n` 之后执行任意系统命令==

```http
POST http://127.0.0.1:9999/api/v1/toolbox/device/update/swap HTTP/1.1
Host: 127.0.0.1:9999
sec-ch-ua: "Chromium";v="105", "Not)A;Brand";v="8"
Accept: application/json, text/plain, */*
Accept-Language: zh
sec-ch-ua-mobile: ?0
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.5195.102 Safari/537.36
sec-ch-ua-platform: "macOS"
Sec-Fetch-Site: same-origin
Sec-Fetch-Mode: cors
Sec-Fetch-Dest: empty
Referer: http://127.0.0.1:9999/containers/container
Accept-Encoding: gzip, deflate
Cookie: psession=b10c76ce-5502-48b1-8705-eca3d390ee61
Connection: close
Content-Type: application/json
Content-Length: 40

{"Path":"123123123\nopen -a Calculator"}
```

![](https://pic.l1nyz-tel.cc/202403082140649.png)