### PR TITLE
fix: 修复应用商店详情页面部分图标比例错误

### DIFF
--- a/frontend/src/views/app-store/detail/index.vue
+++ b/frontend/src/views/app-store/detail/index.vue
@@ -6,7 +6,7 @@
         <div class="brief" v-loading="loadingApp">
             <div class="detail flex">
                 <div class="w-12 h-12 rounded p-1 shadow-md icon">
-                    <img :src="app.icon" alt="App Icon" class="w-full h-full rounded" />
+                    <img :src="app.icon" alt="App Icon" class="w-full h-full rounded object-contain" />
                 </div>
                 <div class="ml-4">
                     <div class="name mb-2">

--- a/frontend/src/views/app-store/detail/index.vue
+++ b/frontend/src/views/app-store/detail/index.vue
@@ -6,7 +6,7 @@
         <div class="brief" v-loading="loadingApp">
             <div class="detail flex">
                 <div class="w-12 h-12 rounded p-1 shadow-md icon">
-                    <img :src="app.icon" alt="App Icon" class="w-full h-full rounded object-contain" />
+                    <img :src="app.icon" alt="App Icon" class="w-full h-full rounded" style="object-fit: contain" />
                 </div>
                 <div class="ml-4">
                     <div class="name mb-2">


### PR DESCRIPTION
#### What this PR does / why we need it?

![image](https://github.com/1Panel-dev/1Panel/assets/66513481/1fd83f7e-88f9-4b1f-953c-2f11717bcfd6)

部分宽高不等的图标在详情页面显示比例错误

#### Summary of your change

添加了 object-contain 样式

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.