### PR TITLE
解决部分操作系统上 platformVersion 为空导致的显示问题

### DIFF
--- a/frontend/src/views/home/index.vue
+++ b/frontend/src/views/home/index.vue
@@ -172,7 +172,7 @@
                                             {{ $t('home.platformVersion') }}
                                         </span>
                                     </template>
-                                    {{ baseInfo.platform }}-{{ baseInfo.platformVersion }}
+                                    {{ baseInfo.platformVersion === "" ? baseInfo.platform : baseInfo.platform + "-" + baseInfo.platformVersion }}
                                 </el-descriptions-item>
                                 <el-descriptions-item class-name="system-content">
                                     <template #label>

--- a/frontend/src/views/home/index.vue
+++ b/frontend/src/views/home/index.vue
@@ -172,7 +172,7 @@
                                             {{ $t('home.platformVersion') }}
                                         </span>
                                     </template>
-                                    {{ baseInfo.platformVersion === "" ? baseInfo.platform : baseInfo.platform + "-" + baseInfo.platformVersion }}
+                                    {{ baseInfo.platformVersion === "" ? baseInfo.platform : (baseInfo.platform + "-" + baseInfo.platformVersion) }}
                                 </el-descriptions-item>
                                 <el-descriptions-item class-name="system-content">
                                     <template #label>


### PR DESCRIPTION
例如archlinux，显示的是：arch-

<img width="859" alt="截屏2024-03-21 14 42 14" src="https://github.com/1Panel-dev/1Panel/assets/261698/80123b97-65ea-4bd0-a4ca-7a54649ec93c">


#### What this PR does / why we need it?

To fix displaying problem of Platform version when platformVersion is empty.

#### Summary of your change

Check if platformVersion is empty.

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.