### PR TITLE
feat: 面板配置https后，浏览器使用http协议访问自动重定向到https协议

### DIFF
--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -28,6 +28,7 @@ import (
 	"github.com/1Panel-dev/1Panel/backend/init/viper"
 
 	"github.com/gin-gonic/gin"
+	"github.com/bddjr/hlfhr"
 )
 
 func Start() {
@@ -54,10 +55,10 @@ func Start() {
 		tcpItem = "tcp"
 		global.CONF.System.BindAddress = fmt.Sprintf("[%s]", global.CONF.System.BindAddress)
 	}
-	server := &http.Server{
+	server := hlfhr.New(&http.Server{
 		Addr:    global.CONF.System.BindAddress + ":" + global.CONF.System.Port,
 		Handler: rootRouter,
-	}
+	})
 	ln, err := net.Listen(tcpItem, server.Addr)
 	if err != nil {
 		panic(err)

--- a/go.mod
+++ b/go.mod
@@ -86,6 +86,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.22.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.27.0 // indirect
 	github.com/aws/smithy-go v1.20.0 // indirect
+	github.com/bddjr/hlfhr v0.0.4 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bodgit/plumbing v1.3.0 // indirect
 	github.com/bodgit/sevenzip v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.27.0 h1:cjTRjh700H36MQ8M0LnDn33W3Jmw
 github.com/aws/aws-sdk-go-v2/service/sts v1.27.0/go.mod h1:nXfOBMWPokIbOY+Gi7a1psWMSvskUCemZzI+SMB7Akc=
 github.com/aws/smithy-go v1.20.0 h1:6+kZsCXZwKxZS9RfISnPc4EXlHoyAkm2hPuM8X2BrrQ=
 github.com/aws/smithy-go v1.20.0/go.mod h1:uo5RKksAl4PzhqaAbjd4rLgFoq5koTsQKYuGe7dklGc=
+github.com/bddjr/hlfhr v0.0.4 h1:Vb5Bc23wGwvrjVogiRDYaSl1OlB1EamAq+XeJlTwZa8=
+github.com/bddjr/hlfhr v0.0.4/go.mod h1:oyIv4Q9JpCgZFdtH3KyTNWp7YYRWl4zl8k4ozrMAB4g=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20150223135152-b965b613227f/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=


### PR DESCRIPTION
#### What this PR does / why we need it?
[FEATURE] 面板配置https后，浏览器使用http协议访问自动重定向到https协议 #3886

#### Summary of your change
由 https://github.com/bddjr/hlfhr 接管 `ServeTLS`

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.