### PR TITLE
fix: 解决进程守护启动命令带空格导致报错的问题

### DIFF
--- a/frontend/src/global/mimetype.ts
+++ b/frontend/src/global/mimetype.ts
@@ -161,7 +161,7 @@ export const DNSTypes = [
         value: 'DnsPod',
     },
     {
-        label: 'CloudFlare',
+        label: 'Cloudflare',
         value: 'CloudFlare',
     },
     {

--- a/frontend/src/views/toolbox/supervisor/create/index.vue
+++ b/frontend/src/views/toolbox/supervisor/create/index.vue
@@ -21,7 +21,7 @@
                         </el-input>
                     </el-form-item>
                     <el-form-item :label="$t('tool.supervisor.command')" prop="command">
-                        <el-input v-model="process.command"></el-input>
+                        <el-input v-model.trim="process.command"></el-input>
                     </el-form-item>
                     <el-form-item :label="$t('tool.supervisor.numprocs')" prop="numprocsNum">
                         <el-input type="number" v-model.number="process.numprocsNum"></el-input>


### PR DESCRIPTION
Refs https://github.com/1Panel-dev/1Panel/issues/4888