### PR TITLE
fix: 修复分块上传文件资源未释放问题

### DIFF
--- a/backend/app/api/v1/file.go
+++ b/backend/app/api/v1/file.go
@@ -609,7 +609,7 @@ func mergeChunks(fileName string, fileDir string, dstDir string, chunkCount int)
 	if err != nil {
 		return err
 	}
-
+	defer targetFile.Close()
 	for i := 0; i < chunkCount; i++ {
 		chunkPath := filepath.Join(fileDir, fmt.Sprintf("%s.%d", fileName, i))
 		chunkData, err := os.ReadFile(chunkPath)


### PR DESCRIPTION
释放占用的文件
上传的可执行文件老提示 text file busy