### PR TITLE
fix: the issue where the auto theme is invalid due to an incorrect class setting

### DIFF
--- a/frontend/src/hooks/use-theme.ts
+++ b/frontend/src/hooks/use-theme.ts
@@ -32,6 +32,9 @@ export const useTheme = () => {
     };
 
     const updateTheme = (theme: string) => {
+        if (theme === 'auto') {
+            theme = prefersDark.matches ? 'dark' : 'light';
+        }
         const body = document.documentElement as HTMLElement;
         body.setAttribute('class', theme);
     };


### PR DESCRIPTION
#### What this PR does / why we need it?

解决由于跟随系统主题设置 class 错误所导致的样式问题。

#### Summary of your change

由于 `useTheme` 会在调用时触发 `onBeforeMount` 方法，因此会导致当启用《跟随系统主题》后，用户手动点击例如 “面板设置“ 等包含 `useTheme` 的页面时，会被切换为亮色模式。

```release-note
None
```