### PR TITLE
fix: 端口转发功能在ufw下重启面板导致Docker自带规则被清除

### DIFF
--- a/backend/init/app/app.go
+++ b/backend/init/app/app.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"fmt"
 	"github.com/1Panel-dev/1Panel/backend/utils/docker"
 	"github.com/1Panel-dev/1Panel/backend/utils/firewall"
 	"path"
@@ -35,7 +34,7 @@ func Init() {
 	_ = docker.CreateDefaultDockerNetwork()
 
 	if f, err := firewall.NewFirewallClient(); err == nil {
-		fmt.Println(f.EnableForward())
+		_ = f.EnableForward()
 	}
 }
 

--- a/backend/init/app/app.go
+++ b/backend/init/app/app.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"github.com/1Panel-dev/1Panel/backend/utils/docker"
 	"github.com/1Panel-dev/1Panel/backend/utils/firewall"
 	"path"
@@ -34,7 +35,7 @@ func Init() {
 	_ = docker.CreateDefaultDockerNetwork()
 
 	if f, err := firewall.NewFirewallClient(); err == nil {
-		_ = f.EnableForward()
+		fmt.Println(f.EnableForward())
 	}
 }
 

--- a/backend/utils/firewall/client/ufw.go
+++ b/backend/utils/firewall/client/ufw.go
@@ -289,6 +289,21 @@ func (f *Ufw) EnableForward() error {
 	if err != nil {
 		return err
 	}
+	_ = iptables.NatNewChain()
 
+	rules, err := iptables.NatList("PREROUTING")
+	if err != nil {
+		return err
+	}
+	for _, rule := range rules {
+		if rule.Target == NatChain {
+			goto reload
+		}
+	}
+
+	if err = iptables.NatAppendChain(); err != nil {
+		return err
+	}
+reload:
 	return iptables.Reload()
 }


### PR DESCRIPTION
#### What this PR does / why we need it?
ufw下重启1p时会刷新整个nat表，导致Docker自己的转发规则被清除

#### Summary of your change
重写ufw下iptables网络方案，改为自定义新Chain处理1P的端口转发规则，不再影响其它软件的iptables功能

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.