### PR TITLE
docs: 修改 readme 中 UI 展示图片为可跳转到介绍

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
   [<a href="docs/README_TW.md">中文(繁體)</a>] | [<a href="docs/README_EN.md">English</a>] | [<a href="docs/README_JP.md">日本語</a>]
 </p>
 
+[![Watch the video](https://resource.fit2cloud.com/1panel/img/overview.png)](https://www.bilibili.com/video/BV1Mt421n7LZ/)
+
 ------------------------------
 
 1Panel 是新一代的 Linux 服务器运维管理面板。

--- a/README.md
+++ b/README.md
@@ -41,10 +41,6 @@ curl -sSL https://resource.fit2cloud.com/1panel/package/quick_start.sh -o quick_
 - [社区论坛](https://bbs.fit2cloud.com/c/1p/7)
 - [如何加入微信交流群?](https://bbs.fit2cloud.com/t/topic/2147)
 
-## UI 展示
-
-![UI展示](https://resource.fit2cloud.com/1panel/img/overview.png)
-
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=1Panel-dev/1Panel&type=Date)](https://star-history.com/#1Panel-dev/1Panel&Date)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   [<a href="docs/README_TW.md">中文(繁體)</a>] | [<a href="docs/README_EN.md">English</a>] | [<a href="docs/README_JP.md">日本語</a>]
 </p>
 
-[![Watch the video](https://resource.fit2cloud.com/1panel/img/overview.png)](https://www.bilibili.com/video/BV1Mt421n7LZ/)
+[![Watch the video](https://resource.fit2cloud.com/1panel/img/overview_video.png)](https://www.bilibili.com/video/BV1Mt421n7LZ/)
 
 ------------------------------
 


### PR DESCRIPTION
#### Summary of your change

调整了默认简中 readme 中的 UI 展示图片位置，并可以点击跳转到介绍视频。

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.