### PR TITLE
feat: 文件管理文本编辑后退出前保存提示

### DIFF
--- a/frontend/src/lang/modules/en.ts
+++ b/frontend/src/lang/modules/en.ts
@@ -64,6 +64,8 @@ const message = {
             agree: 'Agree',
             notAgree: 'Not Agree',
             preview: 'Preview',
+            open: 'Open',
+            notSave: 'Not Save',
         },
         search: {
             timeStart: 'Time start',
@@ -143,6 +145,7 @@ const message = {
             recoverHelper: 'Restoring from {0} file. This operation is irreversible. Do you want to continue?',
             refreshSuccess: 'Refresh successful',
             rootInfoErr: "It's already the root directory",
+            resetSuccess: 'Reset successful',
         },
         login: {
             username: 'UserName',
@@ -1222,9 +1225,12 @@ const message = {
         back: 'Back',
         top: 'Go Back',
         refresh: 'Refresh',
+        up: 'Go back',
         openWithVscode: 'Open with VS Code',
         vscodeHelper: 'Please make sure that VS Code is installed locally and the SSH Remote plugin is configured',
-        up: 'Go back',
+        saveContentAndClose: 'The file has been modified, do you want to save and close it?',
+        saveAndOpenNewFile: 'The file has been modified, do you want to save and open the new file?',
+        noEdit: 'The file has not been modified, no need to do this!',
     },
     ssh: {
         autoStart: 'Auto Start',

--- a/frontend/src/lang/modules/tw.ts
+++ b/frontend/src/lang/modules/tw.ts
@@ -63,6 +63,8 @@ const message = {
             agree: '同意',
             notAgree: '不同意',
             preview: '預覽',
+            open: '打開',
+            notSave: '不保存',
         },
         search: {
             timeStart: '開始時間',
@@ -143,6 +145,7 @@ const message = {
             recoverHelper: '將從 {0} 文件進行恢復，該操作不可回滾，是否繼續？',
             refreshSuccess: '重繪成功',
             rootInfoErr: '已經是根目錄了',
+            resetSuccess: '重置成功',
         },
         login: {
             username: '用戶名',
@@ -1163,6 +1166,9 @@ const message = {
         up: '上一層',
         openWithVscode: 'VS Code 打開',
         vscodeHelper: '請確保本地已安裝 VS Code 並配置了 SSH Remote 插件',
+        saveContentAndClose: '檔案已被修改，是否保存並關閉？',
+        saveAndOpenNewFile: '檔案已被修改，是否保存並打開新檔案？',
+        noEdit: '檔案未修改，無需此操作！',
     },
     ssh: {
         autoStart: '開機自啟',

--- a/frontend/src/lang/modules/zh.ts
+++ b/frontend/src/lang/modules/zh.ts
@@ -63,6 +63,8 @@ const message = {
             agree: '同意',
             notAgree: '不同意',
             preview: '预览',
+            open: '打开',
+            notSave: '不保存',
         },
         search: {
             timeStart: '开始时间',
@@ -143,6 +145,7 @@ const message = {
             recoverHelper: '将从 {0} 文件进行恢复，该操作不可回滚，是否继续？',
             refreshSuccess: '刷新成功',
             rootInfoErr: '已经是根目录了',
+            resetSuccess: '重置成功',
         },
         login: {
             username: '用户名',
@@ -1164,6 +1167,9 @@ const message = {
         up: '上一级',
         openWithVscode: 'VS Code 打开',
         vscodeHelper: '请确保本地已安装 VS Code 并配置了 SSH Remote 插件',
+        saveContentAndClose: '文件已被修改，是否保存并关闭？',
+        saveAndOpenNewFile: '文件已被修改，是否保存并打开新文件？',
+        noEdit: '文件未修改,无需此操作！',
     },
     ssh: {
         autoStart: '开机自启',


### PR DESCRIPTION
#### What this PR does / why we need it?
Refs #5356
#### Summary of your change
检测文本是否编辑，退出/切换文件作出提示，可以重置当前修改！
#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.