### PR TITLE
fix: 判断文件是否为二进制文件，忽略文本类型文件

### DIFF
--- a/backend/utils/files/fileinfo.go
+++ b/backend/utils/files/fileinfo.go
@@ -7,6 +7,7 @@ import (
 	"github.com/1Panel-dev/1Panel/backend/buserr"
 	"github.com/1Panel-dev/1Panel/backend/constant"
 	"io/fs"
+	"net/http"
 	"os"
 	"os/exec"
 	"path"
@@ -335,17 +336,21 @@ func (f *FileInfo) getContent() error {
 }
 
 func DetectBinary(buf []byte) bool {
-	whiteByte := 0
-	n := min(1024, len(buf))
-	for i := 0; i < n; i++ {
-		if (buf[i] >= 0x20) || buf[i] == 9 || buf[i] == 10 || buf[i] == 13 {
-			whiteByte++
-		} else if buf[i] <= 6 || (buf[i] >= 14 && buf[i] <= 31) {
-			return true
+	mimeType := http.DetectContentType(buf)
+	if !strings.HasPrefix(mimeType, "text/") {
+		whiteByte := 0
+		n := min(1024, len(buf))
+		for i := 0; i < n; i++ {
+			if (buf[i] >= 0x20) || buf[i] == 9 || buf[i] == 10 || buf[i] == 13 {
+				whiteByte++
+			} else if buf[i] <= 6 || (buf[i] >= 14 && buf[i] <= 31) {
+				return true
+			}
 		}
+		return whiteByte < 1
 	}
+	return false
 
-	return whiteByte < 1
 }
 
 func min(x, y int) int {


### PR DESCRIPTION
Refs #5722 