### PR TITLE
fix: 监听编辑器内容变化事件调整

### DIFF
--- a/frontend/src/views/host/file-management/code-editor/index.vue
+++ b/frontend/src/views/host/file-management/code-editor/index.vue
@@ -393,17 +393,17 @@ const initEditor = () => {
             let defaultContent = '\n\n\n\n';
             editor.getModel().setValue(defaultContent);
         }
+
+        editor.getModel().pushEOL(config.eol);
+
+        editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, quickSave);
+
         editor.onDidChangeModelContent(() => {
             if (editor) {
                 form.value.content = editor.getValue();
                 isEdit.value = true;
             }
         });
-
-        // After onDidChangeModelContent
-        editor.getModel().pushEOL(config.eol);
-
-        editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, quickSave);
     });
 };
 


### PR DESCRIPTION
调整监听编辑器内容变化事件到初始化编辑器之后，避免编辑器初始化时导致默认内容被视为用户编辑行为。