### PR TITLE
fix: 创建CA机构生成的应为证书而非证书签名请求

### DIFF
--- a/backend/app/service/website_ca.go
+++ b/backend/app/service/website_ca.go
@@ -432,14 +432,14 @@ func (w WebsiteCAService) DownloadFile(id uint) (*os.File, error) {
 	if err = fileOp.CreateDir(dir, 0666); err != nil {
 		return nil, err
 	}
-	if err = fileOp.WriteFile(path.Join(dir, "ca.csr"), strings.NewReader(ca.CSR), 0644); err != nil {
+	if err = fileOp.WriteFile(path.Join(dir, "ca.crt"), strings.NewReader(ca.CSR), 0644); err != nil {
 		return nil, err
 	}
-	if err = fileOp.WriteFile(path.Join(dir, "private.key"), strings.NewReader(ca.PrivateKey), 0644); err != nil {
+	if err = fileOp.WriteFile(path.Join(dir, "ca.key"), strings.NewReader(ca.PrivateKey), 0644); err != nil {
 		return nil, err
 	}
 	fileName := ca.Name + ".zip"
-	if err = fileOp.Compress([]string{path.Join(dir, "ca.csr"), path.Join(dir, "private.key")}, dir, fileName, files.SdkZip, ""); err != nil {
+	if err = fileOp.Compress([]string{path.Join(dir, "ca.crt"), path.Join(dir, "ca.key")}, dir, fileName, files.SdkZip, ""); err != nil {
 		return nil, err
 	}
 	return os.Open(path.Join(dir, fileName))

--- a/frontend/src/views/website/ssl/ca/detail/index.vue
+++ b/frontend/src/views/website/ssl/ca/detail/index.vue
@@ -6,7 +6,7 @@
         <div v-loading="loading">
             <el-radio-group v-model="curr">
                 <el-radio-button value="detail">{{ $t('ssl.organizationDetail') }}</el-radio-button>
-                <el-radio-button value="ssl">csr</el-radio-button>
+                <el-radio-button value="ssl">{{ $t('ssl.ssl') }}</el-radio-button>
                 <el-radio-button value="key">{{ $t('ssl.key') }}</el-radio-button>
             </el-radio-group>
             <div v-if="curr === 'detail'" class="mt-5">


### PR DESCRIPTION
#### What this PR does / why we need it?
This PR fixes an issue where the generated output when creating a CA (Certificate Authority) was mistakenly a Certificate Signing Request (CSR) instead of the intended certificate.
- Adjusted the labels for radio buttons in the UI to reflect the correct functionality.
#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.