### PR TITLE
fix: 解决图片/视频预览时，重命名文件名导致浏览器缓存文件内容问题

### DIFF
--- a/frontend/src/views/host/file-management/preview/index.vue
+++ b/frontend/src/views/host/file-management/preview/index.vue
@@ -115,7 +115,9 @@ const acceptParams = (props: EditProps) => {
     isFullscreen.value = fileType.value === 'excel';
 
     loading.value = true;
-    fileUrl.value = `${import.meta.env.VITE_API_URL as string}/files/download?path=${encodeURIComponent(props.path)}`;
+    fileUrl.value = `${import.meta.env.VITE_API_URL as string}/files/download?path=${encodeURIComponent(
+        props.path,
+    )}&timestamp=${new Date().getTime()}`;
     open.value = true;
     loading.value = false;
 };


### PR DESCRIPTION
Refs #6505
