### PR TITLE
feat:firewalld和ufw同时存在时,不进行操作

### DIFF
--- a/backend/utils/firewall/client.go
+++ b/backend/utils/firewall/client.go
@@ -29,10 +29,17 @@ type FirewallClient interface {
 }
 
 func NewFirewallClient() (FirewallClient, error) {
-	if _, err := os.Stat("/usr/sbin/firewalld"); err == nil {
+	_, firewalldErr := os.Stat("/usr/sbin/firewalld")
+	_, ufwErr := os.Stat("/usr/sbin/ufw")
+
+	if firewalldErr == nil && ufwErr == nil {
+		return nil, buserr.New("firewalld and ufw both found, only one firewall should be active")
+	}
+
+	if firewalldErr == nil {
 		return client.NewFirewalld()
 	}
-	if _, err := os.Stat("/usr/sbin/ufw"); err == nil {
+	if ufwErr == nil {
 		return client.NewUfw()
 	}
 	return nil, buserr.New(constant.ErrFirewall)


### PR DESCRIPTION
#### What this PR does / why we need it?

firewalled和ufw同时存在时操作报错.
原因: 使用ufw进行防火墙管理,如果系统同时安装了firewalled,会导致规则覆盖,因为代码优先使用firewalled

#### Summary of your change

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.