### PR TITLE
fix: 修复 pure-ftpd 上传缓慢问题

### DIFF
--- a/backend/utils/toolbox/pure-ftpd.go
+++ b/backend/utils/toolbox/pure-ftpd.go
@@ -152,13 +152,16 @@ func (f *Ftp) SetPasswd(username, passwd string) error {
 	scanner := bufio.NewScanner(pwdFile)
 	for scanner.Scan() {
 		line := scanner.Text()
-		if strings.HasPrefix(line, username) {
-			userEntry := strings.Split(line, ":")
-			userEntry[1] = string(hashedPassword)
-			line = strings.Join(userEntry, ":")
-		}
 		if line == "" {
 			continue
+		}
+		userEntry := strings.Split(line, ":")
+		if len(userEntry) < 2 {
+			continue
+		}
+		if userEntry[0] == username {
+			userEntry[1] = string(hashedPassword)
+			line = strings.Join(userEntry, ":")
 		}
 		entrys = append(entrys, line)
 	}

--- a/backend/utils/toolbox/pure-ftpd.go
+++ b/backend/utils/toolbox/pure-ftpd.go
@@ -1,8 +1,10 @@
 package toolbox
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
+	"golang.org/x/crypto/bcrypt"
 	"os"
 	"os/user"
 	"path"
@@ -19,6 +21,21 @@ import (
 type Ftp struct {
 	DefaultUser  string
 	DefaultGroup string
+}
+
+type FtpList struct {
+	User   string
+	Path   string
+	Status string
+}
+
+type FtpLog struct {
+	IP        string `json:"ip"`
+	User      string `json:"user"`
+	Time      string `json:"time"`
+	Operation string `json:"operation"`
+	Status    string `json:"status"`
+	Size      string `json:"size"`
 }
 
 type FtpClient interface {
@@ -88,9 +105,19 @@ func (f *Ftp) Operate(operate string) error {
 }
 
 func (f *Ftp) UserAdd(username, passwd, path string) error {
-	std, err := cmd.Execf("pure-pw useradd %s -u %s -d %s <<EOF \n%s\n%s\nEOF", username, f.DefaultUser, path, passwd, passwd)
+	entry, err := generatePureFtpEntrySimple(username, passwd, path)
 	if err != nil {
-		return errors.New(std)
+		return err
+	}
+	pwdFile, err := os.OpenFile("/etc/pure-ftpd/pureftpd.passwd", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer pwdFile.Close()
+
+	_, err = pwdFile.WriteString("\n" + entry + "\n")
+	if err != nil {
+		return err
 	}
 	_ = f.Reload()
 	std2, err := cmd.Execf("chown -R %s:%s %s", f.DefaultUser, f.DefaultGroup, path)
@@ -110,10 +137,51 @@ func (f *Ftp) UserDel(username string) error {
 }
 
 func (f *Ftp) SetPasswd(username, passwd string) error {
-	std, err := cmd.Execf("pure-pw passwd %s <<EOF \n%s\n%s\nEOF", username, passwd, passwd)
+	hashedPassword, err := hashPassword(passwd)
 	if err != nil {
-		return errors.New(std)
+		return err
 	}
+	// read now
+	pwdFile, err := os.Open("/etc/pure-ftpd/pureftpd.passwd")
+	if err != nil {
+		return err
+	}
+	defer pwdFile.Close()
+
+	var entrys []string
+	scanner := bufio.NewScanner(pwdFile)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, username) {
+			userEntry := strings.Split(line, ":")
+			userEntry[1] = string(hashedPassword)
+			line = strings.Join(userEntry, ":")
+		}
+		if line == "" {
+			continue
+		}
+		entrys = append(entrys, line)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	pwdFile.Close()
+
+	// write new
+	pwdFile, err = os.Create("/etc/pure-ftpd/pureftpd.passwd")
+	if err != nil {
+		return err
+	}
+	defer pwdFile.Close()
+
+	for _, entry := range entrys {
+		_, err := pwdFile.WriteString(entry + "\n")
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -166,12 +234,6 @@ func (f *Ftp) LoadList() ([]FtpList, error) {
 		lists = append(lists, FtpList{User: parts[0], Path: strings.ReplaceAll(parts[1], "/./", ""), Status: status})
 	}
 	return lists, nil
-}
-
-type FtpList struct {
-	User   string
-	Path   string
-	Status string
 }
 
 func (f *Ftp) Reload() error {
@@ -262,11 +324,51 @@ func loadLogsByFiles(fileList []string, user, operation string) []FtpLog {
 	return logs
 }
 
-type FtpLog struct {
-	IP        string `json:"ip"`
-	User      string `json:"user"`
-	Time      string `json:"time"`
-	Operation string `json:"operation"`
-	Status    string `json:"status"`
-	Size      string `json:"size"`
+func hashPassword(password string) ([]byte, error) {
+	// Hash the password using bcrypt with a cost of 10
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		return nil, err
+	}
+	return hashedPassword, nil
+}
+
+func generatePureFtpEntrySimple(username, password, path string) (string, error) {
+	return generatePureFtpEntry(username, password, 1000, 1000, "", path+"/./",
+		"", "", "", "", "",
+		"", "", "", "", "", "", "")
+}
+
+func generatePureFtpEntry(username, password string, uid, gid int, gecos, homedir,
+	uploadBandwidth, downloadBandwidth, uploadRatio, downloadRatio, maxConnections, filesQuota, sizeQuota,
+	authorizedLocalIPs, refusedLocalIPs, authorizedClientIPs, refusedClientIPs, timeRestrictions string) (string, error) {
+
+	hashedPassword, err := hashPassword(password)
+	if err != nil {
+		return "", err
+	}
+
+	// Format the entry
+	entry := fmt.Sprintf("%s:%s:%d:%d:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s",
+		username,
+		hashedPassword,
+		uid,
+		gid,
+		gecos,
+		homedir,
+		uploadBandwidth,
+		downloadBandwidth,
+		uploadRatio,
+		downloadRatio,
+		maxConnections,
+		filesQuota,
+		sizeQuota,
+		authorizedLocalIPs,
+		refusedLocalIPs,
+		authorizedClientIPs,
+		refusedClientIPs,
+		timeRestrictions,
+	)
+
+	return entry, nil
 }


### PR DESCRIPTION
#### What this PR does / why we need it?
pure-ftpd 上传缓慢是由于 login 过程中 Argon2id 算法的密码校验导致的，所以通过调整加密算法来处理 FTP 上传过程中的卡顿问题。

The slow upload in pure-ftpd is due to the Argon2id algorithm used for password verification during the login process. To address the lag in the FTP upload process, consider adjusting the encryption algorithm.

#### Summary of your change
调整了 pure-ftpd 加密算法，由 Argon2id 变更为 Bcrypt，已达到安全和速度的平衡。
影响范围：新增和修改用户密码，将不在使用原生 pure-pw 命令。其他操作不影响。

The encryption algorithm in pure-ftpd has been changed from Argon2id to Bcrypt, achieving a balance between security and speed. 
Scope of impact: This change affects only the creation and modification of user passwords, which will no longer use the native pure-pw command. Other operations are unaffected.

#### Please indicate you've done the following:

- [✅] Made sure tests are passing and test coverage is added if needed.
- [✅] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [✅] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.