### PR TITLE
Fix invalid postion of before content in home page

### DIFF
--- a/frontend/src/components/card-with-header/index.vue
+++ b/frontend/src/components/card-with-header/index.vue
@@ -29,9 +29,11 @@ defineProps({
             font-size: 16px;
             font-weight: 500;
             margin-left: 18px;
+            display: flex;
             &::before {
                 position: absolute;
-                top: 4px;
+                top: 50%;
+                transform: translateY(-50%);
                 left: -13px;
                 width: 4px;
                 height: 14px;


### PR DESCRIPTION
#### What this PR does / why we need it?

When I open 1Panel in Firefox on Linux(133.0.3) and Chrome(131.0.6778.139), all before contents of headers in home page are born in a wrong position. Please see the screenshot below:

![image](https://github.com/user-attachments/assets/589fbf05-89a2-4e4a-bf70-81090d43910e)

![image](https://github.com/user-attachments/assets/dc1e55b0-6a4f-4947-9481-3b4c66854dbe)

This PR fixes the problem completely. See the screenshots below:

![image](https://github.com/user-attachments/assets/7d4934cb-8e14-4423-8428-ce44835238bf)

![image](https://github.com/user-attachments/assets/a65d07ec-7f06-42be-b9e5-cb446a805358)

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.

```release-note
None
```