### PR TITLE
fix: Remove `proxy_cache ` from the global config to prevent it from being enabled for sites that don't need caching.

### DIFF
--- a/cmd/server/nginx_conf/cache.conf
+++ b/cmd/server/nginx_conf/cache.conf
@@ -9,4 +9,3 @@ proxy_buffers 4 64k;
 proxy_busy_buffers_size 128k;
 proxy_temp_file_write_size 128k;
 proxy_next_upstream error timeout invalid_header http_500 http_503 http_404;
-proxy_cache proxy_cache_panel;


### PR DESCRIPTION
#### What this PR does / why we need it?
Fix the problem in https://bbs.fit2cloud.com/t/topic/8868.
#### Summary of your change
Removed `proxy_cache` from global cache configuration.
#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.