### PR TITLE
feat: allow tencent cloud cos dual stack domain

### DIFF
--- a/backend/utils/cloud_storage/client/cos.go
+++ b/backend/utils/cloud_storage/client/cos.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 
 	cosSDK "github.com/tencentyun/cos-go-sdk-v5"
 )
@@ -18,6 +19,7 @@ type cosClient struct {
 
 func NewCosClient(vars map[string]interface{}) (*cosClient, error) {
 	region := loadParamFromVars("region", vars)
+	endpoint := loadParamFromVars("endpoint", vars)
 	accessKey := loadParamFromVars("accessKey", vars)
 	secretKey := loadParamFromVars("secretKey", vars)
 	bucket := loadParamFromVars("bucket", vars)
@@ -26,7 +28,16 @@ func NewCosClient(vars map[string]interface{}) (*cosClient, error) {
 		scType = "Standard"
 	}
 
-	u, _ := url.Parse(fmt.Sprintf("https://cos.%s.myqcloud.com", region))
+	// 允许使用对象存储双栈域名
+	endpointType := "cos"
+	if len(endpoint) != 0 {
+		re := regexp.MustCompile(`.*cos-dualstack\..*`)
+		if re.MatchString(endpoint) {
+			endpointType = "cos-dualstack"
+		}
+	}
+
+	u, _ := url.Parse(fmt.Sprintf("https://%s.%s.myqcloud.com", endpointType, region))
 	b := &cosSDK.BaseURL{BucketURL: u}
 	client := cosSDK.NewClient(b, &http.Client{
 		Transport: &cosSDK.AuthorizationTransport{
@@ -36,7 +47,7 @@ func NewCosClient(vars map[string]interface{}) (*cosClient, error) {
 	})
 
 	if len(bucket) != 0 {
-		u2, _ := url.Parse(fmt.Sprintf("https://%s.cos.%s.myqcloud.com", bucket, region))
+		u2, _ := url.Parse(fmt.Sprintf("https://%s.%s.%s.myqcloud.com", bucket, endpointType, region))
 		b2 := &cosSDK.BaseURL{BucketURL: u2}
 		clientWithBucket := cosSDK.NewClient(b2, &http.Client{
 			Transport: &cosSDK.AuthorizationTransport{


### PR DESCRIPTION
#### What this PR does / why we need it?
Support the dual-stack domain name of IPv4/IPv6 for Tencent Cloud Object Storage.

#### Summary of your change
After the parameter similar to `<bucketname>.cos-dualstack.<region>.myqcloud.com` is passed in from the endpoint, modify the domain name of the Tencent Cloud SDK client to `cos-dualstack.<region>.myqcloud.com` to support usage in pure IPv6 networks.   

If this parameter is not provided, the default will be maintained.

Currently, Ipv6 enabled regions are known: ap-beijing, ap-nanjing, ap-shanghai, ap-guangzhou. Other areas cannot be accessed if this parameter is used.

Reference: https://cloud.tencent.com/developer/article/1561701

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.