### PR TITLE
fix: the docker image which no tag but used be pruned

### DIFF
--- a/frontend/src/views/container/image/prune/index.vue
+++ b/frontend/src/views/container/image/prune/index.vue
@@ -70,9 +70,11 @@ const acceptParams = async (): Promise<void> => {
     unUsedList.value = [];
     for (const item of list) {
         if (
-            !item.tags ||
-            item.tags.length === 0 ||
-            (item.tags.length === 1 && item.tags[0].indexOf('<none>') !== -1 && !item.isUsed)
+            (
+                !item.tags ||
+                item.tags.length === 0 ||
+                (item.tags.length === 1 && item.tags[0].indexOf('<none>') !== -1)
+            ) && !item.isUsed
         ) {
             unTagList.value.push(item);
         }


### PR DESCRIPTION
#### What this PR does / why we need it?

fix like it:

![image](https://github.com/user-attachments/assets/6e2c78ee-cde5-4ae2-a3b5-f0f3821a760b)

#### Summary of your change

check is used for all no tag image

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.