### PR TITLE
feat: Move current status to first position in MySQL settings and set…

### DIFF
--- a/frontend/src/views/database/mysql/setting/index.vue
+++ b/frontend/src/views/database/mysql/setting/index.vue
@@ -4,9 +4,6 @@
             <template #title>
                 <back-button name="MySQL" :header="props.database + ' ' + $t('commons.button.set')">
                     <template #buttons>
-                        <el-button type="primary" :plain="activeName !== 'conf'" @click="jumpToConf">
-                            {{ $t('database.confChange') }}
-                        </el-button>
                         <el-button
                             type="primary"
                             :disabled="mysqlStatus !== 'Running'"
@@ -14,6 +11,9 @@
                             @click="activeName = 'status'"
                         >
                             {{ $t('database.currentStatus') }}
+                        </el-button>
+                        <el-button type="primary" :plain="activeName !== 'conf'" @click="jumpToConf">
+                            {{ $t('database.confChange') }}
                         </el-button>
                         <el-button
                             type="primary"
@@ -159,7 +159,7 @@ const globalStore = GlobalStore();
 const loading = ref(false);
 
 const extensions = [javascript(), oneDark];
-const activeName = ref('conf');
+const activeName = ref('status');
 
 const baseInfo = reactive({
     name: '',

--- a/frontend/src/views/database/redis/setting/index.vue
+++ b/frontend/src/views/database/redis/setting/index.vue
@@ -2,9 +2,6 @@
     <div v-show="settingShow" v-loading="loading">
         <LayoutContent :title="database + ' ' + $t('commons.button.set')" :reload="true">
             <template #buttons>
-                <el-button type="primary" :plain="activeName !== 'conf'" @click="changeTab('conf')">
-                    {{ $t('database.confChange') }}
-                </el-button>
                 <el-button
                     type="primary"
                     :disabled="redisStatus !== 'Running'"
@@ -12,6 +9,9 @@
                     @click="changeTab('status')"
                 >
                     {{ $t('database.currentStatus') }}
+                </el-button>
+                <el-button type="primary" :plain="activeName !== 'conf'" @click="changeTab('conf')">
+                    {{ $t('database.confChange') }}
                 </el-button>
                 <el-button
                     type="primary"
@@ -170,7 +170,7 @@ const rules = reactive({
     maxmemory: [Rules.number, checkNumberRange(0, 999999)],
 });
 
-const activeName = ref('conf');
+const activeName = ref('status');
 const statusRef = ref();
 const persistenceRef = ref();
 
@@ -217,7 +217,7 @@ const acceptParams = (prop: DialogProps): void => {
     redisStatus.value = prop.status;
     database.value = prop.database;
     settingShow.value = true;
-    loadConfFile();
+    changeTab('status');
 };
 
 const portRef = ref();


### PR DESCRIPTION
#### What this PR does / why we need it?

#8877  This PR updates the MySQL settings UI by moving the "Current Status" section to the top of the tab list and setting it as the default active tab. This improves the user experience by immediately displaying the most relevant information when users open the settings.

#### Summary of your change

- Reordered the tabs in the MySQL settings component.
- Set the "Current Status" tab as the default selected tab on load.
- Made necessary adjustments to ensure consistent behavior across sessions if applicable.

#### Please indicate you've done the following:

- [X]  Made sure tests are passing and test coverage is added if needed.
-  [X] Made sure commit message follow the rule of [[Conventional Commits specification](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org/).
- [X]  Considered the docs impact and opened a new docs issue or PR with docs changes if needed.

```release-note
Move "Current Status" to the first position in MySQL settings and set it as the default tab.
```