### PR TITLE
feat: add name attrs to login inputs for password managers to recognize

### DIFF
--- a/frontend/src/views/login/components/login-form.vue
+++ b/frontend/src/views/login/components/login-form.vue
@@ -72,6 +72,7 @@
                     </div>
                     <el-form-item prop="name" class="no-border">
                         <el-input
+                            name="username"
                             v-model.trim="loginForm.name"
                             :placeholder="$t('commons.login.username')"
                             class="form-input"
@@ -85,6 +86,7 @@
                     </el-form-item>
                     <el-form-item prop="password" class="no-border">
                         <el-input
+                            name="password"
                             type="password"
                             clearable
                             v-model.trim="loginForm.password"


### PR DESCRIPTION
#### What this PR does / why we need it?
This PR adds name attributes to the username and password input fields in the login form to help password managers correctly identify and autofill these fields. In the current version, Bitwarden does not trigger the autofill button when clicking these inputs without the name attributes.
当前点击用户名和密码的输入框，不会弹出Bitwarden的按钮，是因为没有对应的识别信息，加上name就能识别了。

Before:
![image](https://github.com/user-attachments/assets/ef40d5f6-2df0-481f-aea7-3e0d51ff483e)

After:
![image](https://github.com/user-attachments/assets/72ef53fb-2025-4477-998c-2743548afd3e)

#### Summary of your change
Added name attributes to login inputs to fix password manager autofill detection issues.

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.