### PR TITLE
Fix Issue with Podman Unable to Create PHP Runtime Website

### DIFF
--- a/agent/app/service/container.go
+++ b/agent/app/service/container.go
@@ -1240,6 +1240,25 @@ func checkImageExist(client *client.Client, imageItem string) bool {
 	return false
 }
 
+func checkImageLike(imageName string) bool {
+	cli, err := docker.NewDockerClient()
+	if err != nil {
+		return false
+	}
+	images, err := cli.ImageList(context.Background(), image.ListOptions{})
+	if err != nil {
+		return false
+	}
+	for _, img := range images {
+		for _, tag := range img.RepoTags {
+			if strings.Contains(tag, imageName) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func pullImages(task *task.Task, client *client.Client, imageName string) error {
 	dockerCli := docker.NewClientWithExist(client)
 	options := image.PullOptions{}

--- a/agent/app/service/website.go
+++ b/agent/app/service/website.go
@@ -388,7 +388,7 @@ func (w WebsiteService) CreateWebsite(create request.WebsiteCreate) (err error) 
 		switch runtime.Type {
 		case constant.RuntimePHP:
 			if runtime.Resource == constant.ResourceAppstore {
-				if !checkImageExist(nil, runtime.Image) {
+				if !checkImageLike(runtime.Image) {
 					return buserr.WithName("ErrImageNotExist", runtime.Name)
 				}
 				website.Proxy = fmt.Sprintf("127.0.0.1:%s", runtime.Port)


### PR DESCRIPTION
#### What this PR does / why we need it?

When using Podman's symbolic link as a replacement for Docker, creating a web page that uses the PHP environment results in an error.

#### Summary of your change

Like https://github.com/1Panel-dev/1Panel/pull/7253