### PR TITLE
fix: Fix crash when adding custom spec if specs is null

### DIFF
--- a/frontend/src/views/cronjob/cronjob/operate/index.vue
+++ b/frontend/src/views/cronjob/cronjob/operate/index.vue
@@ -834,7 +834,7 @@ const search = async () => {
                 form.type = res.data.type;
                 form.specCustom = res.data.specCustom;
                 form.spec = res.data.spec;
-                form.specs = res.data.specs;
+                form.specs = res.data.specs || [];
                 if (!form.specCustom && form.spec) {
                     let objs = [];
                     for (const item of res.data.spec.split(',')) {


### PR DESCRIPTION
#### What this PR does / why we need it?

修改使用非自定义创建的计划任务，切换至自定义后无法新增自定义执行周期。

<img width="873" height="664" alt="image" src="https://github.com/user-attachments/assets/ca8e1a6c-d285-4b56-9525-c98e0d9c50f3" />

<img width="859" height="926" alt="image" src="https://github.com/user-attachments/assets/f92399f1-361b-4a21-8849-18750a1126a0" />

#### Summary of your change

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.