### PR TITLE
Fix Issue with Podman Unable to Change PHP Runtime in Website Page

### DIFF
--- a/agent/app/service/container.go
+++ b/agent/app/service/container.go
@@ -1240,23 +1240,30 @@ func checkImageExist(client *client.Client, imageItem string) bool {
 	return false
 }
 
-func checkImageLike(imageName string) bool {
-	cli, err := docker.NewDockerClient()
-	if err != nil {
-		return false
-	}
-	images, err := cli.ImageList(context.Background(), image.ListOptions{})
-	if err != nil {
-		return false
-	}
-	for _, img := range images {
-		for _, tag := range img.RepoTags {
-			if strings.Contains(tag, imageName) {
-				return true
-			}
-		}
-	}
-	return false
+func checkImageLike(client *client.Client, imageName string) bool {
+    if client == nil {
+        var err error
+        client, err = docker.NewDockerClient()
+        if err != nil {
+            return false
+        }
+    }
+    images, err := client.ImageList(context.Background(), image.ListOptions{})
+    if err != nil {
+        return false
+    }
+
+    for _, img := range images {
+        for _, tag := range img.RepoTags {
+            parts := strings.Split(tag, "/")
+            imageNameWithTag := parts[len(parts)-1]
+
+            if imageNameWithTag == imageName {
+                return true
+            }
+        }
+    }
+    return false
 }
 
 func pullImages(task *task.Task, client *client.Client, imageName string) error {

--- a/agent/app/service/website.go
+++ b/agent/app/service/website.go
@@ -388,7 +388,7 @@ func (w WebsiteService) CreateWebsite(create request.WebsiteCreate) (err error) 
 		switch runtime.Type {
 		case constant.RuntimePHP:
 			if runtime.Resource == constant.ResourceAppstore {
-				if !checkImageLike(runtime.Image) {
+				if !checkImageLike(nil, runtime.Image) {
 					return buserr.WithName("ErrImageNotExist", runtime.Name)
 				}
 				website.Proxy = fmt.Sprintf("127.0.0.1:%s", runtime.Port)
@@ -1354,7 +1354,7 @@ func (w WebsiteService) ChangePHPVersion(req request.WebsitePHPVersionReq) error
 			return err
 		}
 		defer client.Close()
-		if !checkImageExist(client, oldRuntime.Image) {
+		if !checkImageLike(client, oldRuntime.Image) {
 			return buserr.WithName("ErrImageNotExist", oldRuntime.Name)
 		}
 	}


### PR DESCRIPTION
#### What this PR does / why we need it?

When using Podman, the output image names are not completely consistent with Docker, which causes validation failures on the Website page and prevents PHP version switching.

#### Summary of your change

Modify the logic for determining image names when switching PHP versions.