### PR TITLE
fix: Move inline editorconfig comments

### DIFF
--- a/frontend/.editorconfig
+++ b/frontend/.editorconfig
@@ -2,14 +2,24 @@
 
 root = true
 
-[*] # 表示所有文件适用
-charset = utf-8 # 设置文件字符集为 utf-8
-end_of_line = lf # 控制换行类型(lf | cr | crlf)
-insert_final_newline = true # 始终在文件末尾插入一个新行
-indent_style = space # 缩进风格（tab | space）
-indent_size = 4 # 缩进大小
-max_line_length = 120 # 最大行长度
+# 表示所有文件适用
+[*]
+# 设置文件字符集为 utf-8
+charset = utf-8
+# 控制换行类型(lf | cr | crlf)
+end_of_line = lf
+# 始终在文件末尾插入一个新行
+insert_final_newline = true
+# 缩进风格（tab | space）
+indent_style = space
+# 缩进大小
+indent_size = 4
+# 最大行长度
+max_line_length = 120
 
-[*.md] # 表示仅 md 文件适用以下规则
-max_line_length = off # 关闭最大行长度限制
-trim_trailing_whitespace = false # 关闭末尾空格修剪
+# 表示仅 md 文件适用以下规则
+[*.md]
+# 关闭最大行长度限制
+max_line_length = off
+# 关闭末尾空格修剪
+trim_trailing_whitespace = false


### PR DESCRIPTION
#### What this PR does / why we need it?

To fix warnings on some editors
[EditorConfig specs](https://spec.editorconfig.org/#no-inline-comments)

#### Summary of your change

Move all comments in the editorconfig file to a new line

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.