### PR TITLE
fix: Improve config handling for proxy configuration in GetProxies

### DIFF
--- a/agent/app/service/website.go
+++ b/agent/app/service/website.go
@@ -1787,9 +1787,15 @@ func (w WebsiteService) GetProxies(id uint) (res []request.WebsiteProxyConfig, e
 		}
 		directives := config.GetDirectives()
 
-		location, ok := directives[0].(*components.Location)
-		if !ok {
-			err = errors.New("error")
+		var location *components.Location
+		for _, directive := range directives {
+			if loc, ok := directive.(*components.Location); ok {
+				location = loc
+				break
+			}
+		}
+		if location == nil {
+			err = errors.New("invalid proxy config, no location found")
 			return
 		}
 		proxyConfig.ProxyPass = location.ProxyPass


### PR DESCRIPTION
#### What this PR does / why we need it?
Ref #9878
Fixes the issue where GetProxies fails to handle Nginx config files containing multiple location blocks or unexpected directives before the first location block. This improves compatibility with custom Nginx proxy configurations.

#### Summary of your change
Updated the logic in GetProxies to iterate through the parsed directives and find the first valid location block, instead of assuming the first directive is always a location.

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.