### PR TITLE
fix: Enhance OperateProxy location parsing to support custom Nginx configs

### DIFF
--- a/agent/app/service/website.go
+++ b/agent/app/service/website.go
@@ -1632,9 +1632,16 @@ func (w WebsiteService) OperateProxy(req request.WebsiteProxyConfig) (err error)
 
 	config.FilePath = includePath
 	directives := config.Directives
-	location, ok := directives[0].(*components.Location)
-	if !ok {
-		err = errors.New("error")
+
+	var location *components.Location
+	for _, directive := range directives {
+		if loc, ok := directive.(*components.Location); ok {
+			location = loc
+			break
+		}
+	}
+	if location == nil {
+		err = errors.New("invalid proxy config, no location found")
 		return
 	}
 	location.UpdateDirective("proxy_pass", []string{req.ProxyPass})


### PR DESCRIPTION
#### What this PR does / why we need it?
In practical use, reverse proxy configurations may be customized, which can lead to errors when modifying or reading them through the web interface. Previously, the system strictly required the first line to be a location block and allowed only one location block per configuration file. If these conditions were not met, both the modification and reading interfaces would return errors, and recovery through the UI was impossible—manual edits to the reverse proxy configuration were required.

之前的 pr 只给读取改了判断逻辑，遗漏了修改接口的判断，遂补充。

在实际使用中,反向代理配置有可能会发生自定义更改，导致通过网页的更改和读取报错。之前必须严格遵从第一行为 location 块头并且配置文件只能存在一个 location 的情况。如果不遵守该格式，由于强制转换原因，读取接口会返回 error错误并且无法从面板恢复，只能手工更改反向代理配置文件解决。

#### Summary of your change
This PR updates the logic for parsing the location block in reverse proxy configurations (modification and reading interfaces—the reading interface was submitted in a previous PR, this one completes the modification part that was missing). Now, only the first location block in the configuration file is read and affected when editing via the web panel. This change prevents issues where custom configurations or misoperations cause the web panel to fail in reading the reverse proxy settings for a site.

修改反向代理配置的 location 解析逻辑（修改和读取接口，读取接口在上个 pr 已提交，修改接口为补充遗漏）。目前只会读取一个反向代理文件中第一个 符合 location 的块，并且如果用户通过面板修改反向代理，也只会对第一个 location 生效。避免产生难恢复的 error 错误。


#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.