### PR TITLE
fix: Add margin to "View comparison" button and fix "Use custom version" button color issue

### DIFF
--- a/frontend/src/views/app-store/installed/upgrade/diff/index.vue
+++ b/frontend/src/views/app-store/installed/upgrade/diff/index.vue
@@ -7,10 +7,10 @@
         <template #footer>
             <span class="dialog-footer">
                 <el-button @click="handleClose">{{ $t('commons.button.cancel') }}</el-button>
-                <el-button type="success" @click="confirm(true)">
+                <el-button type="primary" @click="confirm(true)">
                     {{ $t('app.useNew') }}
                 </el-button>
-                <el-button type="primary" @click="confirm(false)">
+                <el-button @click="confirm(false)">
                     {{ $t('app.useDefault') }}
                 </el-button>
             </span>
@@ -88,15 +88,5 @@ defineExpose({
 .compose-diff {
     width: 100%;
     height: calc(100vh - 350px);
-}
-.el-button--success:hover {
-    background-color: #4e8e2f !important;
-    border-color: #4e8e2f !important;
-    color: #fff !important;
-}
-.el-button--success:active {
-    background-color: #85ce61 !important;
-    border-color: #85ce61 !important;
-    color: #fff !important;
 }
 </style>

--- a/frontend/src/views/app-store/installed/upgrade/diff/index.vue
+++ b/frontend/src/views/app-store/installed/upgrade/diff/index.vue
@@ -89,4 +89,14 @@ defineExpose({
     width: 100%;
     height: calc(100vh - 350px);
 }
+.el-button--success:hover {
+    background-color: #4e8e2f !important;
+    border-color: #4e8e2f !important;
+    color: #fff !important;
+}
+.el-button--success:active {
+    background-color: #85ce61 !important;
+    border-color: #85ce61 !important;
+    color: #fff !important;
+}
 </style>

--- a/frontend/src/views/app-store/installed/upgrade/index.vue
+++ b/frontend/src/views/app-store/installed/upgrade/index.vue
@@ -57,7 +57,9 @@
             <div v-if="operateReq.operate === 'upgrade'">
                 <el-text type="warning">{{ $t('app.upgradeWarn') }}</el-text>
                 <br />
-                <el-button @click="openDiff()" type="primary">{{ $t('app.showDiff') }}</el-button>
+                <el-button @click="openDiff()" type="primary" style="margin-top: 12px">
+                    {{ $t('app.showDiff') }}
+                </el-button>
                 <div>
                     <el-checkbox v-model="useNewCompose" :label="$t('app.useCustom')" size="large" />
                 </div>

--- a/frontend/src/views/app-store/installed/upgrade/index.vue
+++ b/frontend/src/views/app-store/installed/upgrade/index.vue
@@ -57,7 +57,7 @@
             <div v-if="operateReq.operate === 'upgrade'">
                 <el-text type="warning">{{ $t('app.upgradeWarn') }}</el-text>
                 <br />
-                <el-button @click="openDiff()" type="primary" style="margin-top: 12px">
+                <el-button @click="openDiff()" type="primary" class="mt-2">
                     {{ $t('app.showDiff') }}
                 </el-button>
                 <div>


### PR DESCRIPTION
#### What this PR does / why we need it?
This PR adds margin to the "View comparison" button on the App upgrade page to improve visual layout, and fixes the color issue of the "Use custom version" button on the comparison view.

**old:**
![old](https://github.com/user-attachments/assets/62c4375c-8acb-4bda-a1f6-4daa2ba794e6)


**new:**
![new](https://github.com/user-attachments/assets/b44794a0-dda2-4af6-ae8b-b9b125896072)



#### Summary of your change
- Added spacing (margin) to the "View comparison" button.

- Fixed the button color issue for "Use custom version" on the comparison page, ensuring it behaves correctly on hover and click.

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
UI-only fix.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.  
Not applicable (UI-only fix).