### PR TITLE
fix: Optimize Nginx configure settings

### DIFF
--- a/agent/cmd/server/nginx_conf/website_default.conf
+++ b/agent/cmd/server/nginx_conf/website_default.conf
@@ -4,15 +4,6 @@ server {
 
     index index.php index.html index.htm default.php default.htm default.html;
 
-    proxy_set_header Host $host;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Host $server_name;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "upgrade";
-
-
     access_log /www/sites/domain/log/access.log main;
     error_log /www/sites/domain/log/error.log;
     

--- a/agent/utils/nginx/components/block.go
+++ b/agent/utils/nginx/components/block.go
@@ -38,6 +38,10 @@ func (b *Block) FindDirectives(directiveName string) []IDirective {
 	return directives
 }
 
+func (b *Block) AppendDirectives(directives ...IDirective) {
+	b.Directives = append(b.Directives, directives...)
+}
+
 func (b *Block) UpdateDirective(key string, params []string) {
 	if key == "" || len(params) == 0 {
 		return

--- a/agent/utils/nginx/components/server.go
+++ b/agent/utils/nginx/components/server.go
@@ -332,6 +332,34 @@ func (s *Server) UpdateRootProxy(proxy []string) {
 
 	block.AppendDirectives(
 		&Directive{
+			Name:       "proxy_set_header",
+			Parameters: []string{"Host", "$host"},
+		},
+		&Directive{
+			Name:       "proxy_set_header",
+			Parameters: []string{"X-Forwarded-For", "$proxy_add_x_forwarded_for"},
+		},
+		&Directive{
+			Name:       "proxy_set_header",
+			Parameters: []string{"X-Forwarded-Host", "$server_name"},
+		},
+		&Directive{
+			Name:       "proxy_set_header",
+			Parameters: []string{"X-Real-IP", "$remote_addr"},
+		},
+		&Directive{
+			Name:       "proxy_set_header",
+			Parameters: []string{"Connection", "upgrade"},
+		},
+		&Directive{
+			Name:       "proxy_set_header",
+			Parameters: []string{"Upgrade", "$http_upgrade"},
+		},
+		&Directive{
+			Name:       "proxy_http_version",
+			Parameters: []string{"1.1"},
+		},
+		&Directive{
 			Name:       "proxy_pass",
 			Parameters: proxy,
 		},

--- a/agent/utils/nginx/components/server.go
+++ b/agent/utils/nginx/components/server.go
@@ -267,7 +267,7 @@ func (s *Server) UpdateRootProxyForAi(proxy []string) {
 		Block:      &Block{},
 	}
 	block := &Block{}
-	block.Directives = []IDirective{
+	block.AppendDirectives(
 		&Directive{
 			Name: "proxy_buffering",
 			Parameters: []string{
@@ -298,11 +298,12 @@ func (s *Server) UpdateRootProxyForAi(proxy []string) {
 				"off",
 			},
 		},
-	}
-	block.Directives = append(block.Directives, &Directive{
-		Name:       "proxy_pass",
-		Parameters: proxy,
-	})
+		&Directive{
+			Name:       "proxy_pass",
+			Parameters: proxy,
+		},
+	)
+
 	newDir.Block = block
 	s.UpdateDirectiveBySecondKey("location", "/", newDir)
 }
@@ -314,7 +315,7 @@ func (s *Server) UpdateRootLocation() {
 		Block:      &Block{},
 	}
 	block := &Block{}
-	block.Directives = append(block.Directives, &Directive{
+	block.AppendDirectives(&Directive{
 		Name:       "root",
 		Parameters: []string{"index.html"},
 	})
@@ -328,10 +329,14 @@ func (s *Server) UpdateRootProxy(proxy []string) {
 		Block:      &Block{},
 	}
 	block := &Block{}
-	block.Directives = append(block.Directives, &Directive{
-		Name:       "proxy_pass",
-		Parameters: proxy,
-	})
+
+	block.AppendDirectives(
+		&Directive{
+			Name:       "proxy_pass",
+			Parameters: proxy,
+		},
+	)
+
 	newDir.Block = block
 	s.UpdateDirectiveBySecondKey("location", "/", newDir)
 }
@@ -343,20 +348,22 @@ func (s *Server) UpdatePHPProxy(proxy []string, localPath string) {
 		Block:      &Block{},
 	}
 	block := &Block{}
-	block.Directives = append(block.Directives, &Directive{
-		Name:       "fastcgi_pass",
-		Parameters: proxy,
-	})
-	block.Directives = append(block.Directives, &Directive{
-		Name:       "include",
-		Parameters: []string{"fastcgi-php.conf"},
-	})
-	block.Directives = append(block.Directives, &Directive{
-		Name:       "include",
-		Parameters: []string{"fastcgi_params"},
-	})
+	block.AppendDirectives(
+		&Directive{
+			Name:       "fastcgi_pass",
+			Parameters: proxy,
+		},
+		&Directive{
+			Name:       "include",
+			Parameters: []string{"fastcgi-php.conf"},
+		},
+		&Directive{
+			Name:       "include",
+			Parameters: []string{"fastcgi_params"},
+		},
+	)
 	if localPath == "" {
-		block.Directives = append(block.Directives, &Directive{
+		block.AppendDirectives(&Directive{
 			Name:       "set",
 			Parameters: []string{"$real_script_name", "$fastcgi_script_name"},
 		})
@@ -376,21 +383,23 @@ func (s *Server) UpdatePHPProxy(proxy []string, localPath string) {
 				},
 			},
 		}
-		block.Directives = append(block.Directives, ifDir)
-		block.Directives = append(block.Directives, &Directive{
-			Name:       "fastcgi_param",
-			Parameters: []string{"SCRIPT_FILENAME", "$document_root$real_script_name"},
-		})
-		block.Directives = append(block.Directives, &Directive{
-			Name:       "fastcgi_param",
-			Parameters: []string{"SCRIPT_NAME", "$real_script_name"},
-		})
-		block.Directives = append(block.Directives, &Directive{
-			Name:       "fastcgi_param",
-			Parameters: []string{"PATH_INFO", "$path_info"},
-		})
+		block.AppendDirectives(
+			ifDir,
+			&Directive{
+				Name:       "fastcgi_param",
+				Parameters: []string{"SCRIPT_FILENAME", "$document_root$real_script_name"},
+			},
+			&Directive{
+				Name:       "fastcgi_param",
+				Parameters: []string{"SCRIPT_NAME", "$real_script_name"},
+			},
+			&Directive{
+				Name:       "fastcgi_param",
+				Parameters: []string{"PATH_INFO", "$path_info"},
+			},
+		)
 	} else {
-		block.Directives = append(block.Directives, &Directive{
+		block.AppendDirectives(&Directive{
 			Name:       "fastcgi_param",
 			Parameters: []string{"SCRIPT_FILENAME", localPath},
 		})
@@ -433,7 +442,7 @@ func (s *Server) AddHTTP2HTTPS() {
 		Block:      &Block{},
 	}
 	block := &Block{}
-	block.Directives = append(block.Directives, &Directive{
+	block.AppendDirectives(&Directive{
 		Name:       "return",
 		Parameters: []string{"301", "https://$host$request_uri"},
 	})


### PR DESCRIPTION
#### What this PR does / why we need it?
迁移默认根配置的里的proxy setting到对应的应用部署块中。
这段配置理应在应用部署的根location反代中，而不是在server中，虽然对静态网站或者其他站点模式不会产生影响，但容易与其他用户配置混淆或者造成误解。

后期感觉 server 块应该只放基本配置和部分安全规则，对于实际的反向代理或者路径配置，根据不同站点模式用单独的conf文件配置然后在server 里 include 可能结构会更明确。

Migrate the default root configuration’s proxy settings to the corresponding application deployment block.
These settings should be placed in the root location block of the application’s reverse proxy, rather than in the server block. Although they have no effect on static websites or other site modes, keeping them in the server block can easily cause confusion or misunderstandings with other user configurations.

Going forward, the server block should ideally only contain basic configurations and certain security rules. Actual reverse proxy or path-specific configurations should be placed in separate .conf files according to different site modes, and then included in the server block to make the structure clearer.

#### Test
Before: Current config in App Deployment
<img width="974" height="546" alt="image" src="https://github.com/user-attachments/assets/40b67fa1-0e62-4240-8383-f30ee28b46cb" />

After: Config of this version in App Deployment
<img width="970" height="578" alt="image" src="https://github.com/user-attachments/assets/805e8ae9-64b7-495c-98de-b34e6d5491b7" />

After: Config of this version in Static Website
<img width="1045" height="451" alt="image" src="https://github.com/user-attachments/assets/28d3b209-8642-4fe3-96cb-5495ba12c8de" />


#### Summary of your change
- Simplify `agent/cmd/server/nginx_conf/website_default.conf`
- Migrate Ambiguous Proxy Setting to Right Place
- Added AppendDirectives method to Block for variadic directive appending.
- Replaced multiple block.Directives = append(...) statements with block.AppendDirectives(...) calls across affected methods.

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.