### PR TITLE
fix: resolve null destination when enabling AntiLeech for deployment mode websites

### DIFF
--- a/agent/app/service/website.go
+++ b/agent/app/service/website.go
@@ -2278,10 +2278,10 @@ func (w WebsiteService) UpdateAntiLeech(req request.NginxAntiLeechUpdate) (err e
 			},
 		}
 		newBlock.Directives = append(newBlock.Directives, ifDir)
-		if website.Type == "deployment" {
+		if website.Type == constant.Deployment {
 			newBlock.Directives = append(newBlock.Directives, &components.Directive{
 				Name:       "proxy_pass",
-				Parameters: []string{website.Proxy},
+				Parameters: []string{fmt.Sprintf("http://%s", website.Proxy)},
 			})
 		}
 		newDirective.Block = newBlock

--- a/agent/app/service/website.go
+++ b/agent/app/service/website.go
@@ -2278,6 +2278,12 @@ func (w WebsiteService) UpdateAntiLeech(req request.NginxAntiLeechUpdate) (err e
 			},
 		}
 		newBlock.Directives = append(newBlock.Directives, ifDir)
+		if website.Type == "deployment" {
+			newBlock.Directives = append(newBlock.Directives, &components.Directive{
+				Name:       "proxy_pass",
+				Parameters: []string{website.Proxy},
+			})
+		}
 		newDirective.Block = newBlock
 		index := -1
 		for i, directive := range block.Directives {


### PR DESCRIPTION
#### What this PR does / why we need it?
ref #10105
反向代理/应用部署需要给proxy_pass,不然会回到 nginx站点root目录下

#### Summary of your change
如果是应用部署，则自动在后面追加 proxy_pass

#### Test Result
用应用商店自带的 nextchat 测试
<img width="1536" height="720" alt="image" src="https://github.com/user-attachments/assets/9c32fc31-f178-4ed3-86ce-80a28c84251a" />


#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.


Refs https://github.com/1Panel-dev/1Panel/issues/10105