### PR TITLE
解决目录遍历漏洞问题

### DIFF
--- a/core/init/router/router.go
+++ b/core/init/router/router.go
@@ -30,6 +30,10 @@ func setWebStatic(rootRouter *gin.RouterGroup) {
 	rootRouter.Static("/api/v2/images", path.Join(global.CONF.Base.InstallDir, "1panel/uploads/theme"))
 	rootRouter.GET("/assets/*filepath", func(c *gin.Context) {
 		c.Writer.Header().Set("Cache-Control", fmt.Sprintf("private, max-age=%d", 3600))
+		if c.Request.URL.Path[len(c.Request.URL.Path)-1] == '/' {
+	        c.AbortWithStatus(http.StatusForbidden)
+	        return
+	    }
 		staticServer := http.FileServer(http.FS(web.Assets))
 		staticServer.ServeHTTP(c.Writer, c.Request)
 	})


### PR DESCRIPTION
解决访问面板时的目录遍历漏洞
<img width="491" height="261" alt="image" src="https://github.com/user-attachments/assets/3a29827d-f551-4e39-866e-acc8bb4e53da" />
