### PR TITLE
fix: fix inappropriate directive clean in OperateProxy function

### DIFF
--- a/agent/app/service/website.go
+++ b/agent/app/service/website.go
@@ -1768,14 +1768,14 @@ func (w WebsiteService) OperateProxy(req request.WebsiteProxyConfig) (err error)
 		if req.Preflight {
 			location.AddCorsOption()
 		} else {
-			location.RemoveDirective("if", []string{"(", "$request_method", "=", "'OPTIONS'", ")"})
+			location.RemoveDirectiveByFullParams("if", []string{"(", "$request_method", "=", "'OPTIONS'", ")"})
 		}
 	} else {
 		location.RemoveDirective("add_header", []string{"Access-Control-Allow-Origin"})
 		location.RemoveDirective("add_header", []string{"Access-Control-Allow-Methods"})
 		location.RemoveDirective("add_header", []string{"Access-Control-Allow-Headers"})
 		location.RemoveDirective("add_header", []string{"Access-Control-Allow-Credentials"})
-		location.RemoveDirective("if", []string{"(", "$request_method", "=", "'OPTIONS'", ")"})
+		location.RemoveDirectiveByFullParams("if", []string{"(", "$request_method", "=", "'OPTIONS'", ")"})
 	}
 	if err = nginx.WriteConfig(config, nginx.IndentedStyle); err != nil {
 		return buserr.WithErr("ErrUpdateBuWebsite", err)

--- a/agent/utils/nginx/components/location.go
+++ b/agent/utils/nginx/components/location.go
@@ -197,6 +197,7 @@ func (l *Location) UpdateDirective(key string, params []string) {
 	l.Directives = directives
 }
 
+// RemoveDirective removes a directive by its name and optional FIRST parameter match
 func (l *Location) RemoveDirective(key string, params []string) {
 	directives := l.Directives
 	var newDirectives []IDirective
@@ -209,6 +210,31 @@ func (l *Location) RemoveDirective(key string, params []string) {
 				}
 			} else {
 				continue
+			}
+		}
+		newDirectives = append(newDirectives, dir)
+	}
+	l.Directives = newDirectives
+}
+
+// RemoveDirectiveByFullParams removes a directive by its name and full parameter match
+func (l *Location) RemoveDirectiveByFullParams(key string, params []string) {
+	directives := l.Directives
+	var newDirectives []IDirective
+	for _, dir := range directives {
+		if dir.GetName() == key {
+			oldParams := dir.GetParameters()
+			if len(oldParams) == len(params) {
+				allMatch := true
+				for i, param := range params {
+					if oldParams[i] != param {
+						allMatch = false
+						break
+					}
+				}
+				if allMatch {
+					continue
+				}
 			}
 		}
 		newDirectives = append(newDirectives, dir)
@@ -229,8 +255,8 @@ func (l *Location) ChangePath(Modifier string, Match string) {
 
 func (l *Location) AddCache(cacheTime int, cacheUint, cacheKey string, serverCacheTime int, serverCacheUint string) {
 	l.RemoveDirective("add_header", []string{"Cache-Control", "no-cache"})
-	l.RemoveDirective("if", []string{"(", "$uri", "~*", `"\.(gif|png|jpg|css|js|woff|woff2)$"`, ")"})
-	l.RemoveDirective("if", []string{"(", "$uri", "~*", `"\.(gif|png|jpg|css|js|woff|woff2|jpeg|svg|webp|avif)$"`, ")"})
+	l.RemoveDirectiveByFullParams("if", []string{"(", "$uri", "~*", `"\.(gif|png|jpg|css|js|woff|woff2)$"`, ")"})
+	l.RemoveDirectiveByFullParams("if", []string{"(", "$uri", "~*", `"\.(gif|png|jpg|css|js|woff|woff2|jpeg|svg|webp|avif)$"`, ")"})
 	directives := l.GetDirectives()
 	newDir := &Directive{
 		Name:       "if",
@@ -255,8 +281,8 @@ func (l *Location) AddCache(cacheTime int, cacheUint, cacheKey string, serverCac
 }
 
 func (l *Location) RemoveCache(cacheKey string) {
-	l.RemoveDirective("if", []string{"(", "$uri", "~*", `"\.(gif|png|jpg|css|js|woff|woff2)$"`, ")"})
-	l.RemoveDirective("if", []string{"(", "$uri", "~*", `"\.(gif|png|jpg|css|js|woff|woff2|jpeg|svg|webp|avif)$"`, ")"})
+	l.RemoveDirectiveByFullParams("if", []string{"(", "$uri", "~*", `"\.(gif|png|jpg|css|js|woff|woff2)$"`, ")"})
+	l.RemoveDirectiveByFullParams("if", []string{"(", "$uri", "~*", `"\.(gif|png|jpg|css|js|woff|woff2|jpeg|svg|webp|avif)$"`, ")"})
 	l.RemoveDirective("proxy_ignore_headers", []string{"Set-Cookie"})
 	l.RemoveDirective("proxy_cache", []string{cacheKey})
 	l.RemoveDirective("proxy_cache_key", []string{"$host$uri$is_args$args"})


### PR DESCRIPTION
#### What this PR does / why we need it?
#10747

#### Summary of your change
由于RemoveDirective已经被大量使用，在原函数上做修改可能会有意料之外的问题。而且大部分 directive 一般都是一个 key 一个 param，并且大部分只会在一个块出现一次, 默认这样匹配效率高。
于是另起一个扩展函数RemoveDirectiveByFullParams,对于目前和以后含表达式类且可能会在一个块内出现多次的directive，使用这个函数直接检查全部参数匹配来移除。

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.