### PR TITLE
fix: Change ElementPlus to Auto import

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -18,7 +18,6 @@ import pinia from '@/store/index';
 import SvgIcon from './components/svg-icon/svg-icon.vue';
 import Components from '@/components';
 
-import ElementPlus from 'element-plus';
 import Fit2CloudPlus from 'fit2cloud-ui-plus';
 import * as Icons from '@element-plus/icons-vue';
 
@@ -26,7 +25,6 @@ import directives from '@/directives/index';
 
 const app = createApp(App);
 app.component('SvgIcon', SvgIcon);
-app.use(ElementPlus);
 app.use(Fit2CloudPlus, { locale: i18n.global.messages.value[localStorage.getItem('lang') || 'zh'] });
 
 Object.keys(Icons).forEach((key) => {


### PR DESCRIPTION
#### What this PR does / why we need it?
https://github.com/1Panel-dev/1Panel/issues/10628

看出来开发之前是搞了自动导入的.
https://github.com/1Panel-dev/1Panel/blob/1ef48039542de38d8b846ee5609f32c2285662c5/frontend/vite.config.ts#L80-L94
但是因为之前 main.js 这两行全局导入没清理掉，导致自动导入没生效。
#### Summary of your change
删掉这两行全局导入，就能启动自动导入了，不会全部导入 Element 全部组件，包能小不少。
把 ElementPlus 换成自动导入，减少包大小。
因为已经有unplugin-vue-components unplugin-auto-import了，实测删掉后不会影响开发和打包。
ref: https://element-plus.org/en-US/guide/quickstart

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.