### PR TITLE
chore: replace '登陆' with '登录'

### DIFF
--- a/frontend/src/lang/modules/zh.ts
+++ b/frontend/src/lang/modules/zh.ts
@@ -1562,7 +1562,7 @@ const message = {
         panel: '面板',
         user: '面板用户',
         userChange: '修改面板用户',
-        userChangeHelper: '修改面板用户将退出登陆，是否继续？',
+        userChangeHelper: '修改面板用户将退出登录，是否继续？',
         passwd: '面板密码',
         emailHelper: '用于密码找回',
         watermark: '水印设置',


### PR DESCRIPTION
#### What this PR does / why we need it?

将“修改面板用户”时的提示信息中的“登陆”改为“登录”。

#### Summary of your change

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.