### PR TITLE
fix: Add copy button for image name

### DIFF
--- a/frontend/src/views/container/container/inspect/index.vue
+++ b/frontend/src/views/container/container/inspect/index.vue
@@ -16,6 +16,7 @@
                     </el-descriptions-item>
                     <el-descriptions-item :label="$t('container.image')">
                         {{ inspectData?.Config?.Image }}
+                        <CopyButton :content="inspectData?.Config?.Image || ''" />
                     </el-descriptions-item>
                     <el-descriptions-item :label="$t('commons.table.createdAt')">
                         {{ formatDate(inspectData?.Created) }}


### PR DESCRIPTION
#### What this PR does / why we need it?

#### Summary of your change
容器详情页面给容器Image名称加上复制按钮便于复制当前运行容器的image名称
#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.