### PR TITLE
fix: disable ip input when choosing unsupported network type

### DIFF
--- a/frontend/src/views/container/container/operate/index.vue
+++ b/frontend/src/views/container/container/operate/index.vue
@@ -159,6 +159,7 @@
                                             <el-form-item label="IPv4" prop="ipv4">
                                                 <el-input
                                                     v-model="form.ipv4"
+                                                    :disabled="isIpDisabled"
                                                     :placeholder="$t('container.inputIpv4')"
                                                 />
                                             </el-form-item>
@@ -167,6 +168,7 @@
                                             <el-form-item label="IPv6" prop="ipv6">
                                                 <el-input
                                                     v-model="form.ipv6"
+                                                    :disabled="isIpDisabled"
                                                     :placeholder="$t('container.inputIpv6')"
                                                 />
                                             </el-form-item>
@@ -366,7 +368,7 @@
 </template>
 
 <script lang="ts" setup>
-import { reactive, ref } from 'vue';
+import { reactive, ref, computed, watch } from 'vue';
 import { Rules, checkFloatNumberRange, checkNumberRange } from '@/global/form-rules';
 import i18n from '@/lang';
 import { ElForm } from 'element-plus';
@@ -489,6 +491,20 @@ const rules = reactive({
     nanoCPUs: [Rules.floatNumber],
     memory: [Rules.floatNumber],
 });
+
+const isIpDisabled = computed(() => {
+    return form.network === 'none' || form.network === 'host' || form.network === 'bridge';
+});
+
+watch(
+    () => form.network,
+    (newValue) => {
+        if (newValue === 'none' || newValue === 'host') {
+            form.ipv4 = '';
+            form.ipv6 = '';
+        }
+    },
+);
 
 type FormInstance = InstanceType<typeof ElForm>;
 const formRef = ref<FormInstance>();
@@ -685,9 +701,6 @@ onMounted(() => {
 </script>
 
 <style lang="scss" scoped>
-.widthClass {
-    width: 100%;
-}
 .el-card {
     border: 1px solid var(--el-border-color-light) !important;
 }


### PR DESCRIPTION
#### What this PR does / why we need it?
docker 网络类型选择host或者none时，此时指定ip会报错。如果使用bridge网络，ip会自动分配，ip参数也无效。
#### Summary of your change
用户选择非自定义的网络时，自动禁用和清空 ip输入框

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.