### PR TITLE
chore: disable CSS code splitting in Vite config

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -104,6 +104,7 @@ export default defineConfig(({ mode }: ConfigEnv): UserConfig => {
             outDir: '../core/cmd/server/web',
             minify: 'esbuild',
             target: 'esnext',
+            cssCodeSplit: false,
             rollupOptions: {
                 output: {
                     chunkFileNames: 'assets/js/[name]-[hash].js',


### PR DESCRIPTION
#### What this PR does / why we need it?
css 的 gzip压缩率很高,实测直接把css放一个chunk反而比切割css方案总体流量消耗更小
打包前css:
- 登录首屏: 90kb chunk
- dashboard首屏: 登录首屏 + 52kb chunk
- 后续 css： 每个模块若干个 1kb-2kb 的css chunk
<img width="665" height="652" alt="image" src="https://github.com/user-attachments/assets/520e57c0-197a-49f9-8825-d727c264a039" />

整体打包后 css
- 总体打包 压缩后139kb
<img width="992" height="98" alt="image" src="https://github.com/user-attachments/assets/2b717c0f-66a2-4a11-bb0a-0a72a3cff6d8" />
<img width="491" height="696" alt="image" src="https://github.com/user-attachments/assets/4531bcfd-4a50-4520-accb-e8c539b96801" />

#### Summary of your change
关闭 css 切割。加快其他模块加载速度，但同时会让首次访问登录页变慢。

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.