### PR TITLE
fix: correct suitable log queue size to improve performance

### DIFF
--- a/core/log/config.go
+++ b/core/log/config.go
@@ -15,7 +15,7 @@ var (
 	DefaultFileFlag    = os.O_RDWR | os.O_CREATE | os.O_APPEND
 	ErrInvalidArgument = errors.New("error argument invalid")
 	QueueSize          = 1024
-	LogQueueSize       = 2048
+	LogQueueSize       = 1024
 	ErrClosed          = errors.New("error write on close")
 )
 

--- a/core/log/config.go
+++ b/core/log/config.go
@@ -2,10 +2,11 @@ package log
 
 import (
 	"errors"
-	"github.com/1Panel-dev/1Panel/core/constant"
 	"io"
 	"os"
 	"path"
+
+	"github.com/1Panel-dev/1Panel/core/constant"
 )
 
 var (
@@ -14,6 +15,7 @@ var (
 	DefaultFileFlag    = os.O_RDWR | os.O_CREATE | os.O_APPEND
 	ErrInvalidArgument = errors.New("error argument invalid")
 	QueueSize          = 1024
+	LogQueueSize       = 2048
 	ErrClosed          = errors.New("error write on close")
 )
 

--- a/core/log/writer.go
+++ b/core/log/writer.go
@@ -1,7 +1,6 @@
 package log
 
 import (
-	"github.com/1Panel-dev/1Panel/core/constant"
 	"log"
 	"os"
 	"path"
@@ -10,6 +9,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/1Panel-dev/1Panel/core/constant"
 
 	"github.com/1Panel-dev/1Panel/core/global"
 )
@@ -98,7 +99,7 @@ func NewWriterFromConfig(c *Config) (RollingWriter, error) {
 
 	var rollingWriter RollingWriter
 	writer := Writer{
-		queue:   make(chan []byte, BufferSize),
+		queue:   make(chan []byte, LogQueueSize),
 		m:       mng,
 		file:    file,
 		absPath: filepath,


### PR DESCRIPTION
#### What this PR does / why we need it?
<img width="816" height="249" alt="image" src="https://github.com/user-attachments/assets/1bcf1931-d36d-46a6-9dbf-8f0b17c3f1ed" />
<img width="1149" height="736" alt="image" src="https://github.com/user-attachments/assets/71e9bf26-5da0-4d98-833e-307f5d2c0dcf" />

对 core 分析的时候发现日志初始化函数常驻了惊人的 27MB 内存。多次测试后发现日志队列配置了一个错误的值
错误代码来自于这个 pr 的合并 https://github.com/1Panel-dev/1Panel/pull/10000
<img width="584" height="347" alt="image" src="https://github.com/user-attachments/assets/04bf2599-784d-4ce5-9fd0-e9ee6c08f5fb" />
搞错了 make(chan []byte，#size ) 和 make([]byte, #size ) 导致创建了一个长度高达一百万的队列。


#### Summary of your change
修复 pr 产生的严重 bug,并额外设置了队列常量，给了一个较为保守的值 1024 （实际上可能几百都很难到）。
#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.