### PR TITLE
fix: Update Cache-Control headers for static resources in router

### DIFF
--- a/core/init/router/router.go
+++ b/core/init/router/router.go
@@ -2,7 +2,6 @@ package router
 
 import (
 	"encoding/base64"
-	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -33,7 +32,7 @@ func setWebStatic(rootRouter *gin.RouterGroup) {
 	RegisterImages(rootRouter)
 	setStaticResource(rootRouter)
 	rootRouter.GET("/assets/*filepath", func(c *gin.Context) {
-		c.Writer.Header().Set("Cache-Control", fmt.Sprintf("private, max-age=%d", 2628000))
+		c.Writer.Header().Set("Cache-Control", "private, max-age=2628000, immutable")
 		if c.Request.URL.Path[len(c.Request.URL.Path)-1] == '/' {
 			c.AbortWithStatus(http.StatusForbidden)
 			return
@@ -62,6 +61,7 @@ func setWebStatic(rootRouter *gin.RouterGroup) {
 			entranceValue := base64.StdEncoding.EncodeToString([]byte(entrance))
 			c.SetCookie("SecurityEntrance", entranceValue, 0, "", "", false, true)
 		}
+		c.Writer.Header().Set("Cache-Control", "private, max-age=0, must-revalidate")
 		staticServer := http.FileServer(http.FS(web.IndexHtml))
 		staticServer.ServeHTTP(c.Writer, c.Request)
 	})
@@ -137,7 +137,7 @@ func RegisterImages(rootRouter *gin.RouterGroup) {
 
 func setStaticResource(rootRouter *gin.RouterGroup) {
 	rootRouter.GET("/api/v2/static/*filename", func(c *gin.Context) {
-		c.Writer.Header().Set("Cache-Control", fmt.Sprintf("private, max-age=%d", 2628000))
+		c.Writer.Header().Set("Cache-Control", "private, max-age=2628000")
 		filename := c.Param("filename")
 		filePath := "static" + filename
 		data, err := web.Static.ReadFile(filePath)

--- a/core/init/router/router.go
+++ b/core/init/router/router.go
@@ -61,7 +61,6 @@ func setWebStatic(rootRouter *gin.RouterGroup) {
 			entranceValue := base64.StdEncoding.EncodeToString([]byte(entrance))
 			c.SetCookie("SecurityEntrance", entranceValue, 0, "", "", false, true)
 		}
-		c.Writer.Header().Set("Cache-Control", "private, max-age=0, must-revalidate")
 		staticServer := http.FileServer(http.FS(web.IndexHtml))
 		staticServer.ServeHTTP(c.Writer, c.Request)
 	})


### PR DESCRIPTION
#### What this PR does / why we need it?
参考推荐做法，打包好的vue asset通常文件名有hash, 可视为永远不变，加上immutable 让浏览器完全缓存，避免刷新验证。
<img width="818" height="330" alt="image" src="https://github.com/user-attachments/assets/a7ca093d-c4f2-433a-93d9-8a6930b82101" />

#### Summary of your change
给 asset 下的文件都加上 immutable cache 标记

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.