### PR TITLE
feat: Implement Gzip compression for successful log API responses

### DIFF
--- a/agent/app/api/v2/file.go
+++ b/agent/app/api/v2/file.go
@@ -841,7 +841,11 @@ func (b *BaseApi) ReadFileByLine(c *gin.Context) {
 		helper.InternalServer(c, err)
 		return
 	}
-	helper.SuccessWithData(c, res)
+	if res.TotalLines > 100 {
+		helper.SuccessWithDataGzipped(c, res)
+	} else {
+		helper.SuccessWithData(c, res)
+	}
 }
 
 // @Tags File

--- a/agent/app/api/v2/helper/helper.go
+++ b/agent/app/api/v2/helper/helper.go
@@ -1,10 +1,13 @@
 package helper
 
 import (
+	"compress/gzip"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/1Panel-dev/1Panel/agent/global"
 	"gorm.io/gorm"
@@ -43,6 +46,42 @@ func SuccessWithData(ctx *gin.Context, data interface{}) {
 		Data: data,
 	}
 	ctx.JSON(http.StatusOK, res)
+	ctx.Abort()
+}
+
+func SuccessWithDataGzipped(ctx *gin.Context, data interface{}) {
+	acceptEncoding := ctx.GetHeader("Accept-Encoding")
+	if !strings.Contains(acceptEncoding, "gzip") {
+		SuccessWithData(ctx, data)
+		return
+	}
+	if data == nil {
+		data = gin.H{}
+	}
+	res := dto.Response{
+		Code: http.StatusOK,
+		Data: data,
+	}
+
+	jsonBytes, err := json.Marshal(res)
+	if err != nil {
+		ctx.String(http.StatusInternalServerError, "json marshal error")
+		return
+	}
+
+	ctx.Header("Content-Encoding", "gzip")
+	ctx.Header("Content-Type", "application/json; charset=utf-8")
+
+	gz := gzip.NewWriter(ctx.Writer)
+	defer gz.Close()
+
+	_, err = gz.Write(jsonBytes)
+	if err != nil {
+		ctx.String(http.StatusInternalServerError, "gzip write error")
+		return
+	}
+
+	ctx.Status(http.StatusOK)
 	ctx.Abort()
 }
 

--- a/agent/app/api/v2/helper/helper.go
+++ b/agent/app/api/v2/helper/helper.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/1Panel-dev/1Panel/agent/global"
 	"gorm.io/gorm"
@@ -49,9 +50,14 @@ func SuccessWithData(ctx *gin.Context, data interface{}) {
 	ctx.Abort()
 }
 
+var gzipWriterPool = sync.Pool{
+	New: func() interface{} {
+		return gzip.NewWriter(nil)
+	},
+}
+
 func SuccessWithDataGzipped(ctx *gin.Context, data interface{}) {
-	acceptEncoding := ctx.GetHeader("Accept-Encoding")
-	if !strings.Contains(acceptEncoding, "gzip") {
+	if !strings.Contains(ctx.GetHeader("Accept-Encoding"), "gzip") {
 		SuccessWithData(ctx, data)
 		return
 	}
@@ -62,26 +68,21 @@ func SuccessWithDataGzipped(ctx *gin.Context, data interface{}) {
 		Code: http.StatusOK,
 		Data: data,
 	}
-
 	jsonBytes, err := json.Marshal(res)
 	if err != nil {
-		ctx.String(http.StatusInternalServerError, "json marshal error")
+		ErrorWithDetail(ctx, http.StatusInternalServerError, "ErrInternalServer", err)
 		return
 	}
 
 	ctx.Header("Content-Encoding", "gzip")
 	ctx.Header("Content-Type", "application/json; charset=utf-8")
-
-	gz := gzip.NewWriter(ctx.Writer)
-	defer gz.Close()
-
-	_, err = gz.Write(jsonBytes)
-	if err != nil {
-		ctx.String(http.StatusInternalServerError, "gzip write error")
-		return
-	}
-
 	ctx.Status(http.StatusOK)
+
+	gz := gzipWriterPool.Get().(*gzip.Writer)
+	gz.Reset(ctx.Writer)
+	_, _ = gz.Write(jsonBytes)
+	_ = gz.Close()
+	gzipWriterPool.Put(gz)
 	ctx.Abort()
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it?
读日志的接口，或者其他读大文件的接口，可以用gzip压一下减少带宽压力。
尤其是日志这种重复率极高的内容，压缩率也可以变得很高。
#### Summary of your change
- 扩展 gzip 压缩返回，对于返回量大且重复高的接口，用 gzip 压一遍在发送。
- 给读日志文件的接口应用该方案
优化效果：
124kb->7kb
<img width="765" height="394" alt="image" src="https://github.com/user-attachments/assets/9c7a9693-625f-4536-884e-4dc873f29405" />


#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.