### PR TITLE
refactor: Optimize log file reading logic

### DIFF
--- a/agent/app/service/file.go
+++ b/agent/app/service/file.go
@@ -5,10 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/1Panel-dev/1Panel/agent/app/task"
-	"github.com/1Panel-dev/1Panel/agent/i18n"
-	"github.com/1Panel-dev/1Panel/agent/utils/convert"
-	"github.com/1Panel-dev/1Panel/agent/utils/ini_conf"
 	"io"
 	"io/fs"
 	"os"
@@ -20,6 +16,11 @@ import (
 	"strings"
 	"time"
 	"unicode/utf8"
+
+	"github.com/1Panel-dev/1Panel/agent/app/task"
+	"github.com/1Panel-dev/1Panel/agent/i18n"
+	"github.com/1Panel-dev/1Panel/agent/utils/convert"
+	"github.com/1Panel-dev/1Panel/agent/utils/ini_conf"
 
 	"github.com/1Panel-dev/1Panel/agent/app/dto"
 	"github.com/jinzhu/copier"
@@ -591,7 +592,7 @@ func (f *FileService) ReadLogByLine(req request.FileReadByLineReq) (*response.Fi
 		scope       string
 		logFileRes  *dto.LogFileRes
 	)
-	if stat.Size() > 500*1024*1024 {
+	if stat.Size() > files.MaxReadFileSize {
 		lines, err = files.TailFromEnd(logFilePath, req.PageSize)
 		isEndOfFile = true
 		scope = "tail"

--- a/agent/utils/files/utils.go
+++ b/agent/utils/files/utils.go
@@ -26,7 +26,8 @@ import (
 )
 
 const (
-	maxReadFileSize = 800 * 1024 * 1024
+	MaxReadFileSize = 800 * 1024 * 1024
+	tailBufSize     = int64(32768)
 )
 
 func IsSymlink(mode os.FileMode) bool {
@@ -90,6 +91,13 @@ var readerPool = sync.Pool{
 	},
 }
 
+var tailBufPool = sync.Pool{
+	New: func() interface{} {
+		buf := make([]byte, tailBufSize)
+		return &buf
+	},
+}
+
 func TailFromEnd(filename string, lines int) ([]string, error) {
 	file, err := os.Open(filename)
 	if err != nil {
@@ -103,24 +111,26 @@ func TailFromEnd(filename string, lines int) ([]string, error) {
 	}
 	fileSize := stat.Size()
 
-	bufSize := int64(4096)
+	bufPtr := tailBufPool.Get().(*[]byte)
+	buf := *bufPtr
+	defer tailBufPool.Put(bufPtr)
+
 	var result []string
 	var leftover string
 
 	for offset := fileSize; offset > 0 && len(result) < lines; {
-		readSize := bufSize
-		if offset < bufSize {
+		readSize := tailBufSize
+		if offset < tailBufSize {
 			readSize = offset
 		}
 		offset -= readSize
 
-		buf := make([]byte, readSize)
-		_, err := file.ReadAt(buf, offset)
+		_, err := file.ReadAt(buf[:readSize], offset)
 		if err != nil && err != io.EOF {
 			return nil, err
 		}
 
-		data := string(buf) + leftover
+		data := string(buf[:readSize]) + leftover
 		linesInChunk := strings.Split(data, "\n")
 
 		if offset > 0 {
@@ -131,20 +141,28 @@ func TailFromEnd(filename string, lines int) ([]string, error) {
 		}
 
 		for i := len(linesInChunk) - 1; i >= 0; i-- {
-			if len(result) < lines {
-				if !(i == len(linesInChunk)-1 && linesInChunk[i] == "" && len(result) == 0) {
-					result = append([]string{linesInChunk[i]}, result...)
-				}
+			if len(result) >= lines {
+				break
 			}
+			if i == len(linesInChunk)-1 && linesInChunk[i] == "" && len(result) == 0 {
+				continue
+			}
+			// 反插数据
+			result = append(result, linesInChunk[i])
 		}
 	}
 
 	if leftover != "" && len(result) < lines {
-		result = append([]string{leftover}, result...)
+		result = append(result, leftover)
 	}
 
 	if len(result) > lines {
-		result = result[len(result)-lines:]
+		result = result[:lines]
+	}
+
+	// 反转数据
+	for i, j := 0, len(result)-1; i < j; i, j = i+1, j-1 {
+		result[i], result[j] = result[j], result[i]
 	}
 
 	return result, nil
@@ -165,7 +183,7 @@ func ReadFileByLine(filename string, page, pageSize int, latest bool) (res *dto.
 		return
 	}
 
-	if fi.Size() > maxReadFileSize {
+	if fi.Size() > MaxReadFileSize {
 		err = buserr.New("ErrLogFileToLarge")
 		return
 	}

--- a/agent/utils/files/utils.go
+++ b/agent/utils/files/utils.go
@@ -3,6 +3,15 @@ package files
 import (
 	"bufio"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+
 	"github.com/1Panel-dev/1Panel/agent/app/dto"
 	"github.com/1Panel-dev/1Panel/agent/buserr"
 	"github.com/1Panel-dev/1Panel/agent/constant"
@@ -14,13 +23,10 @@ import (
 	"golang.org/x/text/encoding/simplifiedchinese"
 	"golang.org/x/text/encoding/traditionalchinese"
 	"golang.org/x/text/encoding/unicode"
-	"io"
-	"net/http"
-	"os"
-	"os/user"
-	"path/filepath"
-	"strconv"
-	"strings"
+)
+
+const (
+	maxReadFileSize = 800 * 1024 * 1024
 )
 
 func IsSymlink(mode os.FileMode) bool {
@@ -78,27 +84,10 @@ func IsHidden(path string) bool {
 	return len(base) > 1 && base[0] == dotCharacter
 }
 
-func countLines(path string) (int, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return 0, err
-	}
-	defer file.Close()
-	reader := bufio.NewReader(file)
-	count := 0
-	for {
-		_, err := reader.ReadString('\n')
-		if err != nil {
-			if err == io.EOF {
-				if count > 0 {
-					count++
-				}
-				return count, nil
-			}
-			return count, err
-		}
-		count++
-	}
+var readerPool = sync.Pool{
+	New: func() interface{} {
+		return bufio.NewReaderSize(nil, 8192)
+	},
 }
 
 func TailFromEnd(filename string, lines int) ([]string, error) {
@@ -176,43 +165,92 @@ func ReadFileByLine(filename string, page, pageSize int, latest bool) (res *dto.
 		return
 	}
 
-	if fi.Size() > 500*1024*1024 {
+	if fi.Size() > maxReadFileSize {
 		err = buserr.New("ErrLogFileToLarge")
 		return
 	}
 
-	totalLines, err := countLines(filename)
-	if err != nil {
-		return
-	}
 	res = &dto.LogFileRes{}
-	total := (totalLines + pageSize - 1) / pageSize
-	res.TotalPages = total
-	res.TotalLines = totalLines
-	reader := bufio.NewReaderSize(file, 8192)
+	reader := readerPool.Get().(*bufio.Reader)
+	reader.Reset(file)
+	defer readerPool.Put(reader)
 
 	if latest {
-		page = total
+		ringBuf := make([]string, pageSize)
+		writeIdx := 0
+		totalLines := 0
+
+		for {
+			line, _, readErr := reader.ReadLine()
+			if readErr == io.EOF {
+				break
+			}
+			if readErr != nil {
+				err = readErr
+				return
+			}
+			ringBuf[writeIdx%pageSize] = string(line)
+			writeIdx++
+			totalLines++
+		}
+
+		if totalLines == 0 {
+			res.Lines = []string{}
+			res.TotalLines = 0
+			res.TotalPages = 0
+			res.IsEndOfFile = true
+			return
+		}
+
+		total := (totalLines + pageSize - 1) / pageSize
+		res.TotalPages = total
+		res.TotalLines = totalLines
+
+		lastPageSize := totalLines % pageSize
+		if lastPageSize == 0 {
+			lastPageSize = pageSize
+		}
+		if lastPageSize > totalLines {
+			lastPageSize = totalLines
+		}
+
+		result := make([]string, 0, lastPageSize)
+		startIdx := writeIdx - lastPageSize
+		for i := 0; i < lastPageSize; i++ {
+			idx := (startIdx + i) % pageSize
+			result = append(result, ringBuf[idx])
+		}
+		res.Lines = result
+		res.IsEndOfFile = true
+	} else {
+		startLine := (page - 1) * pageSize
+		endLine := startLine + pageSize
+		currentLine := 0
+		lines := make([]string, 0, pageSize)
+
+		for {
+			line, _, readErr := reader.ReadLine()
+			if readErr == io.EOF {
+				break
+			}
+			if readErr != nil {
+				err = readErr
+				return
+			}
+
+			if currentLine >= startLine && currentLine < endLine {
+				lines = append(lines, string(line))
+			}
+			currentLine++
+		}
+
+		res.Lines = lines
+		res.TotalLines = currentLine
+		total := (currentLine + pageSize - 1) / pageSize
+		res.TotalPages = total
+		res.IsEndOfFile = page >= total
 	}
-	currentLine := 0
-	startLine := (page - 1) * pageSize
-	endLine := startLine + pageSize
-	lines := make([]string, 0, pageSize)
-	for {
-		line, _, err := reader.ReadLine()
-		if err == io.EOF {
-			break
-		}
-		if currentLine >= startLine && currentLine < endLine {
-			lines = append(lines, string(line))
-		}
-		currentLine++
-		if currentLine >= endLine {
-			break
-		}
-	}
-	res.Lines = lines
-	res.IsEndOfFile = currentLine < endLine
+
 	return
 }
 

--- a/agent/utils/files/utils.go
+++ b/agent/utils/files/utils.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	MaxReadFileSize = 800 * 1024 * 1024
+	MaxReadFileSize = 512 * 1024 * 1024
 	tailBufSize     = int64(32768)
 )
 
@@ -96,6 +96,22 @@ var tailBufPool = sync.Pool{
 		buf := make([]byte, tailBufSize)
 		return &buf
 	},
+}
+
+func readLineTrimmed(reader *bufio.Reader) (string, error) {
+	line, err := reader.ReadString('\n')
+	if err == io.EOF {
+		if len(line) == 0 {
+			return "", io.EOF
+		}
+		err = nil
+	}
+	if err != nil {
+		return "", err
+	}
+	line = strings.TrimSuffix(line, "\n")
+	line = strings.TrimSuffix(line, "\r")
+	return line, nil
 }
 
 func TailFromEnd(filename string, lines int) ([]string, error) {
@@ -172,6 +188,10 @@ func ReadFileByLine(filename string, page, pageSize int, latest bool) (res *dto.
 	if !NewFileOp().Stat(filename) {
 		return
 	}
+	if pageSize <= 0 {
+		err = fmt.Errorf("pageSize must be positive")
+		return
+	}
 	file, err := os.Open(filename)
 	if err != nil {
 		return
@@ -199,7 +219,7 @@ func ReadFileByLine(filename string, page, pageSize int, latest bool) (res *dto.
 		totalLines := 0
 
 		for {
-			line, _, readErr := reader.ReadLine()
+			line, readErr := readLineTrimmed(reader)
 			if readErr == io.EOF {
 				break
 			}
@@ -207,7 +227,7 @@ func ReadFileByLine(filename string, page, pageSize int, latest bool) (res *dto.
 				err = readErr
 				return
 			}
-			ringBuf[writeIdx%pageSize] = string(line)
+			ringBuf[writeIdx%pageSize] = line
 			writeIdx++
 			totalLines++
 		}
@@ -247,7 +267,7 @@ func ReadFileByLine(filename string, page, pageSize int, latest bool) (res *dto.
 		lines := make([]string, 0, pageSize)
 
 		for {
-			line, _, readErr := reader.ReadLine()
+			line, readErr := readLineTrimmed(reader)
 			if readErr == io.EOF {
 				break
 			}
@@ -257,7 +277,7 @@ func ReadFileByLine(filename string, page, pageSize int, latest bool) (res *dto.
 			}
 
 			if currentLine >= startLine && currentLine < endLine {
-				lines = append(lines, string(line))
+				lines = append(lines, line)
 			}
 			currentLine++
 		}


### PR DESCRIPTION
#### What this PR does / why we need it?
优化日志读取算法
#### Summary of your change
ReadFileByLine 用环形缓冲队列来统计行，而不是全读一遍。减少一遍全量读写
TailFromEnd 直接后插，最后再翻转过来，减少每次前插的内存开销。
使用sync.pool而不是循环new来麻烦GC
#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.