### PR TITLE
perf: replace gopsutil sampling with cached metrics and optimize system info retrieval

### DIFF
--- a/agent/app/service/alert_helper.go
+++ b/agent/app/service/alert_helper.go
@@ -9,6 +9,7 @@ import (
 	"github.com/1Panel-dev/1Panel/agent/global"
 	alertUtil "github.com/1Panel-dev/1Panel/agent/utils/alert"
 	"github.com/1Panel-dev/1Panel/agent/utils/common"
+	"github.com/1Panel-dev/1Panel/agent/utils/psutil"
 	versionUtil "github.com/1Panel-dev/1Panel/agent/utils/version"
 	"github.com/1Panel-dev/1Panel/agent/utils/xpack"
 	"github.com/shirou/gopsutil/v4/cpu"
@@ -352,7 +353,7 @@ func loadLoadInfo(alert dto.AlertDTO) {
 		return
 	}
 	var loadValue float64
-	CPUTotal, _ := cpu.Counts(true)
+	CPUTotal, _ := psutil.CPUInfo.GetLogicalCores(false)
 	switch alert.Cycle {
 	case 1:
 		loadValue = avgStat.Load1 / (float64(CPUTotal*2) * 0.75) * 100
@@ -839,7 +840,7 @@ func processSingleDisk(alert dto.AlertDTO) error {
 }
 
 func checkAndCreateDiskAlert(alert dto.AlertDTO, path string) (bool, error) {
-	usageStat, err := disk.Usage(path)
+	usageStat, err := psutil.DISK.GetUsage(path, false)
 	if err != nil {
 		global.LOG.Errorf("error getting disk usage for %s, err: %v", path, err)
 		return false, err

--- a/agent/app/service/dashboard.go
+++ b/agent/app/service/dashboard.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -23,10 +24,9 @@ import (
 	"github.com/1Panel-dev/1Panel/agent/utils/common"
 	"github.com/1Panel-dev/1Panel/agent/utils/controller"
 	"github.com/1Panel-dev/1Panel/agent/utils/copier"
+	"github.com/1Panel-dev/1Panel/agent/utils/psutil"
 	"github.com/gin-gonic/gin"
-	"github.com/shirou/gopsutil/v4/cpu"
 	"github.com/shirou/gopsutil/v4/disk"
-	"github.com/shirou/gopsutil/v4/host"
 	"github.com/shirou/gopsutil/v4/load"
 	"github.com/shirou/gopsutil/v4/mem"
 	"github.com/shirou/gopsutil/v4/net"
@@ -77,7 +77,7 @@ func (u *DashboardService) Restart(operation string) error {
 
 func (u *DashboardService) LoadOsInfo() (*dto.OsInfo, error) {
 	var baseInfo dto.OsInfo
-	hostInfo, err := host.Info()
+	hostInfo, err := psutil.HOST.GetHostInfo(false)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func (u *DashboardService) LoadOsInfo() (*dto.OsInfo, error) {
 	baseInfo.KernelArch = hostInfo.KernelArch
 	baseInfo.KernelVersion = hostInfo.KernelVersion
 
-	diskInfo, err := disk.Usage(global.Dir.BaseDir)
+	diskInfo, err := psutil.DISK.GetUsage(global.Dir.BaseDir, false)
 	if err == nil {
 		baseInfo.DiskSize = int64(diskInfo.Free)
 	}
@@ -104,12 +104,16 @@ func (u *DashboardService) LoadOsInfo() (*dto.OsInfo, error) {
 func (u *DashboardService) LoadCurrentInfoForNode() *dto.NodeCurrent {
 	var currentInfo dto.NodeCurrent
 
-	currentInfo.CPUTotal, _ = cpu.Counts(true)
-	totalPercent, _ := cpu.Percent(100*time.Millisecond, false)
-	if len(totalPercent) == 1 {
-		currentInfo.CPUUsedPercent = totalPercent[0]
-		currentInfo.CPUUsed = currentInfo.CPUUsedPercent * 0.01 * float64(currentInfo.CPUTotal)
+	currentInfo.CPUTotal, _ = psutil.CPUInfo.GetLogicalCores(false)
+
+	cpuUsedPercent, perCore := psutil.CPU.GetCPUUsage()
+	if len(perCore) == 0 {
+		currentInfo.CPUTotal = psutil.CPU.NumCPU()
+	} else {
+		currentInfo.CPUTotal = len(perCore)
 	}
+	currentInfo.CPUUsedPercent = cpuUsedPercent
+	currentInfo.CPUUsed = cpuUsedPercent * 0.01 * float64(currentInfo.CPUTotal)
 
 	loadInfo, _ := load.Avg()
 	currentInfo.Load1 = loadInfo.Load1
@@ -134,38 +138,37 @@ func (u *DashboardService) LoadCurrentInfoForNode() *dto.NodeCurrent {
 
 func (u *DashboardService) LoadBaseInfo(ioOption string, netOption string) (*dto.DashboardBase, error) {
 	var baseInfo dto.DashboardBase
-	hostInfo, err := host.Info()
+	hostInfo, err := psutil.HOST.GetHostInfo(false)
 	if err != nil {
 		return nil, err
 	}
-	baseInfo.Hostname = hostInfo.Hostname
-	baseInfo.OS = hostInfo.OS
-	baseInfo.Platform = hostInfo.Platform
-	baseInfo.PlatformFamily = hostInfo.PlatformFamily
-	baseInfo.PlatformVersion = hostInfo.PlatformVersion
-	baseInfo.KernelArch = hostInfo.KernelArch
-	baseInfo.KernelVersion = hostInfo.KernelVersion
 	ss, _ := json.Marshal(hostInfo)
-	baseInfo.VirtualizationSystem = string(ss)
-	baseInfo.IpV4Addr = loadOutboundIP()
-	httpProxy := os.Getenv("http_proxy")
-	if httpProxy == "" {
-		httpProxy = os.Getenv("HTTP_PROXY")
+	baseInfo = dto.DashboardBase{
+		Hostname:             hostInfo.Hostname,
+		OS:                   hostInfo.OS,
+		Platform:             hostInfo.Platform,
+		PlatformFamily:       hostInfo.PlatformFamily,
+		PlatformVersion:      hostInfo.PlatformVersion,
+		KernelArch:           hostInfo.KernelArch,
+		KernelVersion:        hostInfo.KernelVersion,
+		VirtualizationSystem: string(ss),
+		IpV4Addr:             loadOutboundIP(),
+		SystemProxy:          "noProxy",
 	}
-	if httpProxy != "" {
-		baseInfo.SystemProxy = httpProxy
+
+	if proxy := cmp.Or(os.Getenv("http_proxy"), os.Getenv("HTTP_PROXY")); proxy != "" {
+		baseInfo.SystemProxy = proxy
 	}
-	baseInfo.SystemProxy = "noProxy"
 
 	loadQuickJump(&baseInfo)
 
-	cpuInfo, err := cpu.Info()
-	if err == nil {
+	cpuInfo, err := psutil.CPUInfo.GetCPUInfo(false)
+	if err == nil && len(cpuInfo) > 0 {
 		baseInfo.CPUModelName = cpuInfo[0].ModelName
 	}
 
-	baseInfo.CPUCores, _ = cpu.Counts(false)
-	baseInfo.CPULogicalCores, _ = cpu.Counts(true)
+	baseInfo.CPUCores, _ = psutil.CPUInfo.GetPhysicalCores(false)
+	baseInfo.CPULogicalCores, _ = psutil.CPUInfo.GetLogicalCores(false)
 
 	baseInfo.CurrentInfo = *u.LoadCurrentInfo(ioOption, netOption)
 	return &baseInfo, nil
@@ -173,18 +176,21 @@ func (u *DashboardService) LoadBaseInfo(ioOption string, netOption string) (*dto
 
 func (u *DashboardService) LoadCurrentInfo(ioOption string, netOption string) *dto.DashboardCurrent {
 	var currentInfo dto.DashboardCurrent
-	hostInfo, _ := host.Info()
+	hostInfo, _ := psutil.HOST.GetHostInfo(false)
 	currentInfo.Uptime = hostInfo.Uptime
 	currentInfo.TimeSinceUptime = time.Now().Add(-time.Duration(hostInfo.Uptime) * time.Second).Format(constant.DateTimeLayout)
 	currentInfo.Procs = hostInfo.Procs
+	currentInfo.CPUTotal, _ = psutil.CPUInfo.GetLogicalCores(false)
 
-	currentInfo.CPUTotal, _ = cpu.Counts(true)
-	totalPercent, _ := cpu.Percent(100*time.Millisecond, false)
-	if len(totalPercent) == 1 {
-		currentInfo.CPUUsedPercent = totalPercent[0]
-		currentInfo.CPUUsed = currentInfo.CPUUsedPercent * 0.01 * float64(currentInfo.CPUTotal)
+	cpuUsedPercent, perCore := psutil.CPU.GetCPUUsage()
+	if len(perCore) == 0 {
+		currentInfo.CPUTotal = psutil.CPU.NumCPU()
+	} else {
+		currentInfo.CPUTotal = len(perCore)
 	}
-	currentInfo.CPUPercent, _ = cpu.Percent(100*time.Millisecond, true)
+	currentInfo.CPUPercent = perCore
+	currentInfo.CPUUsedPercent = cpuUsedPercent
+	currentInfo.CPUUsed = cpuUsedPercent * 0.01 * float64(currentInfo.CPUTotal)
 
 	loadInfo, _ := load.Avg()
 	currentInfo.Load1 = loadInfo.Load1
@@ -246,6 +252,7 @@ func (u *DashboardService) LoadCurrentInfo(ioOption string, netOption string) *d
 			if state.Name == netOption {
 				currentInfo.NetBytesSent = state.BytesSent
 				currentInfo.NetBytesRecv = state.BytesRecv
+				break
 			}
 		}
 	}
@@ -455,41 +462,52 @@ func loadDiskInfo() []dto.DiskInfo {
 	)
 	wg.Add(len(mounts))
 	for i := 0; i < len(mounts); i++ {
-		go func(timeoutCh <-chan time.Time, mount diskInfo) {
+		go func(mount diskInfo) {
 			defer wg.Done()
 
 			var itemData dto.DiskInfo
 			itemData.Path = mount.Mount
 			itemData.Type = mount.Type
 			itemData.Device = mount.Device
+
+			type diskResult struct {
+				state *disk.UsageStat
+				err   error
+			}
+			resultCh := make(chan diskResult, 1)
+
+			go func() {
+				state, err := psutil.DISK.GetUsage(mount.Mount, false)
+				resultCh <- diskResult{state: state, err: err}
+			}()
+
 			select {
-			case <-timeoutCh:
+			case <-time.After(5 * time.Second):
 				mu.Lock()
 				datas = append(datas, itemData)
 				mu.Unlock()
 				global.LOG.Errorf("load disk info from %s failed, err: timeout", mount.Mount)
-			default:
-				state, err := disk.Usage(mount.Mount)
-				if err != nil {
+			case result := <-resultCh:
+				if result.err != nil {
 					mu.Lock()
 					datas = append(datas, itemData)
 					mu.Unlock()
-					global.LOG.Errorf("load disk info from %s failed, err: %v", mount.Mount, err)
+					global.LOG.Errorf("load disk info from %s failed, err: %v", mount.Mount, result.err)
 					return
 				}
-				itemData.Total = state.Total
-				itemData.Free = state.Free
-				itemData.Used = state.Used
-				itemData.UsedPercent = state.UsedPercent
-				itemData.InodesTotal = state.InodesTotal
-				itemData.InodesUsed = state.InodesUsed
-				itemData.InodesFree = state.InodesFree
-				itemData.InodesUsedPercent = state.InodesUsedPercent
+				itemData.Total = result.state.Total
+				itemData.Free = result.state.Free
+				itemData.Used = result.state.Used
+				itemData.UsedPercent = result.state.UsedPercent
+				itemData.InodesTotal = result.state.InodesTotal
+				itemData.InodesUsed = result.state.InodesUsed
+				itemData.InodesFree = result.state.InodesFree
+				itemData.InodesUsedPercent = result.state.InodesUsedPercent
 				mu.Lock()
 				datas = append(datas, itemData)
 				mu.Unlock()
 			}
-		}(time.After(5*time.Second), mounts[i])
+		}(mounts[i])
 	}
 	wg.Wait()
 

--- a/agent/app/service/monitor.go
+++ b/agent/app/service/monitor.go
@@ -19,6 +19,7 @@ import (
 	"github.com/1Panel-dev/1Panel/agent/utils/ai_tools/gpu"
 	"github.com/1Panel-dev/1Panel/agent/utils/ai_tools/xpu"
 	"github.com/1Panel-dev/1Panel/agent/utils/common"
+	"github.com/1Panel-dev/1Panel/agent/utils/psutil"
 	"github.com/robfig/cron/v3"
 	"github.com/shirou/gopsutil/v4/cpu"
 	"github.com/shirou/gopsutil/v4/disk"
@@ -258,7 +259,7 @@ func (m *MonitorService) Run() {
 			itemModel.TopCPU = string(topItemCPU)
 		}
 	}
-	cpuCount, _ := cpu.Counts(false)
+	cpuCount, _ := psutil.CPUInfo.GetPhysicalCores(false)
 	loadInfo, _ := load.Avg()
 	itemModel.CpuLoad1 = loadInfo.Load1
 	itemModel.CpuLoad5 = loadInfo.Load5

--- a/agent/utils/psutil/cpu.go
+++ b/agent/utils/psutil/cpu.go
@@ -89,7 +89,6 @@ func (c *CPUUsageState) readPerCPUStat() ([]CPUStat, error) {
 	return stats, nil
 }
 
-// readPerCPUStatCopy 读取每个 CPU 核心的统计信息，返回一个新的 slice（不复用）
 func readPerCPUStatCopy() []CPUStat {
 	data, err := os.ReadFile("/proc/stat")
 	if err != nil {
@@ -151,7 +150,6 @@ func (c *CPUUsageState) GetCPUUsage() (float64, []float64) {
 	c.mu.Unlock()
 
 	if needReset {
-		// 在锁外进行采样，避免阻塞其他调用者
 		firstTotal, _ := readCPUStat()
 		firstPer := readPerCPUStatCopy()
 		time.Sleep(100 * time.Millisecond)
@@ -176,7 +174,6 @@ func (c *CPUUsageState) GetCPUUsage() (float64, []float64) {
 		return totalUsage, perCore
 	}
 
-	// 差值采样
 	curTotal, _ := readCPUStat()
 	curPer := readPerCPUStatCopy()
 

--- a/agent/utils/psutil/cpu.go
+++ b/agent/utils/psutil/cpu.go
@@ -1,0 +1,279 @@
+package psutil
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/shirou/gopsutil/v4/cpu"
+)
+
+const (
+	resetInterval = 1 * time.Minute
+	fastInterval  = 3 * time.Second
+)
+
+type CPUStat struct {
+	Idle  uint64
+	Total uint64
+}
+
+type CPUUsageState struct {
+	mu             sync.Mutex
+	lastTotalStat  *CPUStat
+	lastPerCPUStat []CPUStat
+	lastSampleTime time.Time
+
+	cachedTotalUsage float64
+	cachedPerCore    []float64
+}
+
+func readCPUStat() (CPUStat, error) {
+	data, err := os.ReadFile("/proc/stat")
+	if err != nil {
+		return CPUStat{}, err
+	}
+
+	fields := strings.Fields(strings.Split(string(data), "\n")[0])[1:]
+	nums := make([]uint64, len(fields))
+
+	for i, f := range fields {
+		v, _ := strconv.ParseUint(f, 10, 64)
+		nums[i] = v
+	}
+
+	idle := nums[3] + nums[4]
+	var total uint64
+	for _, v := range nums {
+		total += v
+	}
+
+	return CPUStat{Idle: idle, Total: total}, nil
+}
+
+func (c *CPUUsageState) readPerCPUStat() ([]CPUStat, error) {
+	data, err := os.ReadFile("/proc/stat")
+	if err != nil {
+		return nil, err
+	}
+
+	lines := strings.Split(string(data), "\n")
+	stats := c.lastPerCPUStat[:0]
+
+	for _, l := range lines[1:] {
+		if !strings.HasPrefix(l, "cpu") {
+			continue
+		}
+		if len(l) < 4 || l[3] < '0' || l[3] > '9' {
+			continue
+		}
+
+		fields := strings.Fields(l)[1:]
+		nums := make([]uint64, len(fields))
+		for i, f := range fields {
+			v, _ := strconv.ParseUint(f, 10, 64)
+			nums[i] = v
+		}
+
+		idle := nums[3] + nums[4]
+		var total uint64
+		for _, v := range nums {
+			total += v
+		}
+
+		stats = append(stats, CPUStat{Idle: idle, Total: total})
+	}
+
+	return stats, nil
+}
+
+// readPerCPUStatCopy 读取每个 CPU 核心的统计信息，返回一个新的 slice（不复用）
+func readPerCPUStatCopy() []CPUStat {
+	data, err := os.ReadFile("/proc/stat")
+	if err != nil {
+		return nil
+	}
+
+	lines := strings.Split(string(data), "\n")
+	var stats []CPUStat
+
+	for _, l := range lines[1:] {
+		if !strings.HasPrefix(l, "cpu") {
+			continue
+		}
+		if len(l) < 4 || l[3] < '0' || l[3] > '9' {
+			continue
+		}
+
+		fields := strings.Fields(l)[1:]
+		nums := make([]uint64, len(fields))
+		for i, f := range fields {
+			v, _ := strconv.ParseUint(f, 10, 64)
+			nums[i] = v
+		}
+
+		idle := nums[3] + nums[4]
+		var total uint64
+		for _, v := range nums {
+			total += v
+		}
+
+		stats = append(stats, CPUStat{Idle: idle, Total: total})
+	}
+
+	return stats
+}
+
+func calcCPUPercent(prev, cur CPUStat) float64 {
+	deltaIdle := float64(cur.Idle - prev.Idle)
+	deltaTotal := float64(cur.Total - prev.Total)
+	if deltaTotal <= 0 {
+		return 0
+	}
+	return (1 - deltaIdle/deltaTotal) * 100
+}
+
+func (c *CPUUsageState) GetCPUUsage() (float64, []float64) {
+	c.mu.Lock()
+
+	now := time.Now()
+
+	if !c.lastSampleTime.IsZero() && now.Sub(c.lastSampleTime) < fastInterval {
+		result := c.cachedTotalUsage
+		perCore := c.cachedPerCore
+		c.mu.Unlock()
+		return result, perCore
+	}
+
+	needReset := c.lastSampleTime.IsZero() || now.Sub(c.lastSampleTime) >= resetInterval
+	c.mu.Unlock()
+
+	if needReset {
+		// 在锁外进行采样，避免阻塞其他调用者
+		firstTotal, _ := readCPUStat()
+		firstPer := readPerCPUStatCopy()
+		time.Sleep(100 * time.Millisecond)
+		secondTotal, _ := readCPUStat()
+		secondPer := readPerCPUStatCopy()
+
+		totalUsage := calcCPUPercent(firstTotal, secondTotal)
+
+		perCore := make([]float64, len(secondPer))
+		for i := range secondPer {
+			perCore[i] = calcCPUPercent(firstPer[i], secondPer[i])
+		}
+
+		c.mu.Lock()
+		c.cachedTotalUsage = totalUsage
+		c.cachedPerCore = perCore
+		c.lastTotalStat = &secondTotal
+		c.lastPerCPUStat = secondPer
+		c.lastSampleTime = time.Now()
+		c.mu.Unlock()
+
+		return totalUsage, perCore
+	}
+
+	// 差值采样
+	curTotal, _ := readCPUStat()
+	curPer := readPerCPUStatCopy()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	totalUsage := calcCPUPercent(*c.lastTotalStat, curTotal)
+
+	if len(c.cachedPerCore) != len(curPer) {
+		c.cachedPerCore = make([]float64, len(curPer))
+	}
+	for i := range curPer {
+		c.cachedPerCore[i] = calcCPUPercent(c.lastPerCPUStat[i], curPer[i])
+	}
+
+	c.cachedTotalUsage = totalUsage
+	c.lastTotalStat = &curTotal
+	c.lastPerCPUStat = curPer
+	c.lastSampleTime = time.Now()
+
+	return totalUsage, c.cachedPerCore
+}
+
+func (c *CPUUsageState) NumCPU() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return len(c.cachedPerCore)
+}
+
+type CPUInfoState struct {
+	mu               sync.RWMutex
+	initialized      bool
+	cachedInfo       []cpu.InfoStat
+	cachedPhysCores  int
+	cachedLogicCores int
+}
+
+func (c *CPUInfoState) GetCPUInfo(forceRefresh bool) ([]cpu.InfoStat, error) {
+	c.mu.RLock()
+	if c.initialized && c.cachedInfo != nil && !forceRefresh {
+		defer c.mu.RUnlock()
+		return c.cachedInfo, nil
+	}
+	c.mu.RUnlock()
+
+	info, err := cpu.Info()
+	if err != nil {
+		return nil, err
+	}
+
+	c.mu.Lock()
+	c.cachedInfo = info
+	c.initialized = true
+	c.mu.Unlock()
+
+	return info, nil
+}
+
+func (c *CPUInfoState) GetPhysicalCores(forceRefresh bool) (int, error) {
+	c.mu.RLock()
+	if c.initialized && c.cachedPhysCores > 0 && !forceRefresh {
+		defer c.mu.RUnlock()
+		return c.cachedPhysCores, nil
+	}
+	c.mu.RUnlock()
+
+	cores, err := cpu.Counts(false)
+	if err != nil {
+		return 0, err
+	}
+
+	c.mu.Lock()
+	c.cachedPhysCores = cores
+	c.initialized = true
+	c.mu.Unlock()
+
+	return cores, nil
+}
+
+func (c *CPUInfoState) GetLogicalCores(forceRefresh bool) (int, error) {
+	c.mu.RLock()
+	if c.initialized && c.cachedLogicCores > 0 && !forceRefresh {
+		defer c.mu.RUnlock()
+		return c.cachedLogicCores, nil
+	}
+	c.mu.RUnlock()
+
+	cores, err := cpu.Counts(true)
+	if err != nil {
+		return 0, err
+	}
+
+	c.mu.Lock()
+	c.cachedLogicCores = cores
+	c.initialized = true
+	c.mu.Unlock()
+
+	return cores, nil
+}

--- a/agent/utils/psutil/disk.go
+++ b/agent/utils/psutil/disk.go
@@ -1,0 +1,92 @@
+package psutil
+
+import (
+	"sync"
+	"time"
+
+	"github.com/shirou/gopsutil/v4/disk"
+)
+
+const (
+	diskUsageCacheInterval     = 30 * time.Second
+	diskPartitionCacheInterval = 10 * time.Minute
+)
+
+type DiskUsageEntry struct {
+	lastSampleTime time.Time
+	cachedUsage    *disk.UsageStat
+}
+
+type DiskState struct {
+	usageMu    sync.RWMutex
+	usageCache map[string]*DiskUsageEntry
+
+	partitionMu       sync.RWMutex
+	lastPartitionTime time.Time
+	cachedPartitions  []disk.PartitionStat
+}
+
+func (d *DiskState) GetUsage(path string, forceRefresh bool) (*disk.UsageStat, error) {
+	d.usageMu.RLock()
+	if entry, ok := d.usageCache[path]; ok {
+		if time.Since(entry.lastSampleTime) < diskUsageCacheInterval && !forceRefresh {
+			defer d.usageMu.RUnlock()
+			return entry.cachedUsage, nil
+		}
+	}
+	d.usageMu.RUnlock()
+
+	usage, err := disk.Usage(path)
+	if err != nil {
+		return nil, err
+	}
+
+	d.usageMu.Lock()
+	if d.usageCache == nil {
+		d.usageCache = make(map[string]*DiskUsageEntry)
+	}
+	d.usageCache[path] = &DiskUsageEntry{
+		lastSampleTime: time.Now(),
+		cachedUsage:    usage,
+	}
+	d.usageMu.Unlock()
+
+	return usage, nil
+}
+
+func (d *DiskState) GetPartitions(all bool, forceRefresh bool) ([]disk.PartitionStat, error) {
+	d.partitionMu.RLock()
+	if d.cachedPartitions != nil && time.Since(d.lastPartitionTime) < diskPartitionCacheInterval && !forceRefresh {
+		defer d.partitionMu.RUnlock()
+		return d.cachedPartitions, nil
+	}
+	d.partitionMu.RUnlock()
+
+	partitions, err := disk.Partitions(all)
+	if err != nil {
+		return nil, err
+	}
+
+	d.partitionMu.Lock()
+	d.cachedPartitions = partitions
+	d.lastPartitionTime = time.Now()
+	d.partitionMu.Unlock()
+
+	return partitions, nil
+}
+
+func (d *DiskState) ClearUsageCache(path string) {
+	d.usageMu.Lock()
+	delete(d.usageCache, path)
+	d.usageMu.Unlock()
+}
+
+func (d *DiskState) ClearAllCache() {
+	d.usageMu.Lock()
+	d.usageCache = make(map[string]*DiskUsageEntry)
+	d.usageMu.Unlock()
+
+	d.partitionMu.Lock()
+	d.cachedPartitions = nil
+	d.partitionMu.Unlock()
+}

--- a/agent/utils/psutil/global.go
+++ b/agent/utils/psutil/global.go
@@ -1,0 +1,6 @@
+package psutil
+
+var CPU = &CPUUsageState{}
+var CPUInfo = &CPUInfoState{}
+var HOST = &HostInfoState{}
+var DISK = &DiskState{}

--- a/agent/utils/psutil/host.go
+++ b/agent/utils/psutil/host.go
@@ -1,0 +1,38 @@
+package psutil
+
+import (
+	"sync"
+	"time"
+
+	"github.com/shirou/gopsutil/v4/host"
+)
+
+const hostRefreshInterval = 4 * time.Hour
+
+type HostInfoState struct {
+	mu             sync.RWMutex
+	lastSampleTime time.Time
+
+	cachedInfo *host.InfoStat
+}
+
+func (h *HostInfoState) GetHostInfo(forceRefresh bool) (*host.InfoStat, error) {
+	h.mu.RLock()
+	if h.cachedInfo != nil && time.Since(h.lastSampleTime) < hostRefreshInterval && !forceRefresh {
+		defer h.mu.RUnlock()
+		return h.cachedInfo, nil
+	}
+	h.mu.RUnlock()
+
+	hostInfo, err := host.Info()
+	if err != nil {
+		return nil, err
+	}
+
+	h.mu.Lock()
+	h.cachedInfo = hostInfo
+	h.lastSampleTime = time.Now()
+	h.mu.Unlock()
+
+	return hostInfo, nil
+}


### PR DESCRIPTION
#### What this PR does / why we need it?
#11077 #11078 
- 当前调用CPU获取usage的方法每次都需要sleep 100ms,很消耗时间
- 很多几乎不变的数据每次都得调用IO来获取
- systemproxy 值始终不变 
#### Summary of your change
- 自行实现 CPU 库，缓存上一次的 cpu 累计使用时间，每次调用计算当前时间和上一次缓存时间来获取 cpu 使用，而不是 gopsutil 从头 sleep 统计。
- 用 psutil 包套 gopsutil 包，缓存部分变化很慢的信息，下次直接从内存读，无需 IO
- 修复 systemproxy 不变的 Bug

优化时间： 100ms -> 1 μs 左右
![telegram-cloud-photo-size-5-6140758641859038036-x](https://github.com/user-attachments/assets/d879b377-68fb-4273-bf5f-a2d2919f8d35)

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.

#### copilot summary
This pull request refactors system resource monitoring in the agent by introducing a new `psutil` utility package that provides cached and optimized access to CPU, disk, and host information. The changes replace direct usage of `gopsutil` functions throughout the service layer with calls to the new `psutil` abstractions, improving performance and consistency in resource data retrieval. Key updates include changes to CPU and disk usage calculations, host info loading, and dashboard data aggregation.

**System resource access refactoring:**

* Introduced the new `agent/utils/psutil` package, which provides thread-safe, cached access to CPU, disk, and host information through global state objects (`CPU`, `CPUInfo`, `DISK`, `HOST`). [[1]](diffhunk://#diff-fdf756ce2dd9e8e5fee2bd0a022fc5d9c657fbdefe0f08deed6ebe645c586a4fR1-R279) [[2]](diffhunk://#diff-804c067b44a31fe6dd0fbe2ab33b756425e17bd92f9d9b5ef49bd1c17a7a2cf4R1-R92) [[3]](diffhunk://#diff-0d16fcb6f2c469a7c06d8b4a557fe8cc2d3db82757f43d97b6d7efc645af8dc0R1-R38) [[4]](diffhunk://#diff-faea512eb0e369ddbe8661a38e715052f949d3ce711e8f86b9ab2b26c2a7137aR1-R6)
* Refactored all usages of `gopsutil` functions in `agent/app/service/dashboard.go`, `agent/app/service/alert_helper.go`, and `agent/app/service/monitor.go` to use the new `psutil` methods for CPU core counts, CPU usage, disk usage, and host info. [[1]](diffhunk://#diff-a3b39b7279dd5357341de96bcdb080ae61f5720dffeedb672138cecab6cf52a8R12) [[2]](diffhunk://#diff-a3b39b7279dd5357341de96bcdb080ae61f5720dffeedb672138cecab6cf52a8L355-R356) [[3]](diffhunk://#diff-a3b39b7279dd5357341de96bcdb080ae61f5720dffeedb672138cecab6cf52a8L842-R843) [[4]](diffhunk://#diff-4b4edcf83fb82eb7a6f2392f0b4ba4760cab6b0770dc2f39def4efa737db301fR27-L29) [[5]](diffhunk://#diff-4b4edcf83fb82eb7a6f2392f0b4ba4760cab6b0770dc2f39def4efa737db301fL80-R80) [[6]](diffhunk://#diff-4b4edcf83fb82eb7a6f2392f0b4ba4760cab6b0770dc2f39def4efa737db301fL90-R90) [[7]](diffhunk://#diff-4b4edcf83fb82eb7a6f2392f0b4ba4760cab6b0770dc2f39def4efa737db301fL107-R116) [[8]](diffhunk://#diff-4b4edcf83fb82eb7a6f2392f0b4ba4760cab6b0770dc2f39def4efa737db301fL137-R193) [[9]](diffhunk://#diff-2df6194a803126727320110640a6582653ab44172ad773c32b6b8429049c7a14R22) [[10]](diffhunk://#diff-2df6194a803126727320110640a6582653ab44172ad773c32b6b8429049c7a14L261-R262)

**Dashboard and monitoring logic improvements:**

* Updated dashboard and node info loading logic to use cached resource values and improved CPU usage sampling, including per-core statistics. [[1]](diffhunk://#diff-4b4edcf83fb82eb7a6f2392f0b4ba4760cab6b0770dc2f39def4efa737db301fL107-R116) [[2]](diffhunk://#diff-4b4edcf83fb82eb7a6f2392f0b4ba4760cab6b0770dc2f39def4efa737db301fL137-R193)
* Enhanced disk info loading to perform usage sampling in a goroutine with timeout and cache results, increasing reliability and responsiveness.

**Other enhancements:**

* Improved system proxy detection logic in dashboard service using the new `cmp.Or` method for environment variable selection.
* Ensured consistent error handling and logging for resource sampling failures across services. [[1]](diffhunk://#diff-a3b39b7279dd5357341de96bcdb080ae61f5720dffeedb672138cecab6cf52a8L842-R843) [[2]](diffhunk://#diff-4b4edcf83fb82eb7a6f2392f0b4ba4760cab6b0770dc2f39def4efa737db301fL458-R510)