### PR TITLE
feat: async load data of top CPU and memory processes data

### DIFF
--- a/agent/app/api/v2/dashboard.go
+++ b/agent/app/api/v2/dashboard.go
@@ -180,6 +180,28 @@ func (b *BaseApi) LoadDashboardCurrentInfo(c *gin.Context) {
 }
 
 // @Tags Dashboard
+// @Summary Load top cpu processes
+// @Success 200 {Array} dto.Process
+// @Security ApiKeyAuth
+// @Security Timestamp
+// @Router /dashboard/current/top/cpu [get]
+func (b *BaseApi) LoadDashboardTopCPU(c *gin.Context) {
+	data := dashboardService.LoadTopCPU()
+	helper.SuccessWithData(c, data)
+}
+
+// @Tags Dashboard
+// @Summary Load top memory processes
+// @Success 200 {Array} dto.Process
+// @Security ApiKeyAuth
+// @Security Timestamp
+// @Router /dashboard/current/top/mem [get]
+func (b *BaseApi) LoadDashboardTopMem(c *gin.Context) {
+	data := dashboardService.LoadTopMem()
+	helper.SuccessWithData(c, data)
+}
+
+// @Tags Dashboard
 // @Summary System restart
 // @Accept json
 // @Param operation path string true "request"

--- a/agent/app/service/dashboard.go
+++ b/agent/app/service/dashboard.go
@@ -39,6 +39,8 @@ type IDashboardService interface {
 	LoadBaseInfo(ioOption string, netOption string) (*dto.DashboardBase, error)
 	LoadCurrentInfoForNode() *dto.NodeCurrent
 	LoadCurrentInfo(ioOption string, netOption string) *dto.DashboardCurrent
+	LoadTopCPU() []dto.Process
+	LoadTopMem() []dto.Process
 
 	LoadQuickOptions() []dto.QuickJump
 	ChangeQuick(req dto.ChangeQuicks) error
@@ -217,9 +219,6 @@ func (u *DashboardService) LoadCurrentInfo(ioOption string, netOption string) *d
 	currentInfo.GPUData = loadGPUInfo()
 	currentInfo.XPUData = loadXpuInfo()
 
-	currentInfo.TopCPUItems = loadTopCPU()
-	currentInfo.TopMemItems = loadTopMem()
-
 	if ioOption == "all" {
 		diskInfo, _ := disk.IOCounters()
 		for _, state := range diskInfo {
@@ -259,6 +258,14 @@ func (u *DashboardService) LoadCurrentInfo(ioOption string, netOption string) *d
 
 	currentInfo.ShotTime = time.Now()
 	return &currentInfo
+}
+
+func (u *DashboardService) LoadTopCPU() []dto.Process {
+	return loadTopCPU()
+}
+
+func (u *DashboardService) LoadTopMem() []dto.Process {
+	return loadTopMem()
 }
 
 func (u *DashboardService) LoadAppLauncher(ctx *gin.Context) ([]dto.AppLauncher, error) {

--- a/agent/router/ro_dashboard.go
+++ b/agent/router/ro_dashboard.go
@@ -20,6 +20,8 @@ func (s *DashboardRouter) InitRouter(Router *gin.RouterGroup) {
 		cmdRouter.GET("/base/:ioOption/:netOption", baseApi.LoadDashboardBaseInfo)
 		cmdRouter.GET("/current/node", baseApi.LoadCurrentInfoForNode)
 		cmdRouter.GET("/current/:ioOption/:netOption", baseApi.LoadDashboardCurrentInfo)
+		cmdRouter.GET("/current/top/cpu", baseApi.LoadDashboardTopCPU)
+		cmdRouter.GET("/current/top/mem", baseApi.LoadDashboardTopMem)
 		cmdRouter.POST("/system/restart/:operation", baseApi.SystemRestart)
 	}
 }

--- a/frontend/src/api/interface/dashboard.ts
+++ b/frontend/src/api/interface/dashboard.ts
@@ -103,8 +103,8 @@ export namespace Dashboard {
         gpuData: Array<GPUInfo>;
         xpuData: Array<XPUInfo>;
 
-        topCPUItems: Array<Process>;
-        topMemItems: Array<Process>;
+        topCPUItems?: Array<Process>;
+        topMemItems?: Array<Process>;
 
         netBytesSent: number;
         netBytesRecv: number;

--- a/frontend/src/api/modules/dashboard.ts
+++ b/frontend/src/api/modules/dashboard.ts
@@ -29,6 +29,14 @@ export const loadCurrentInfo = (ioOption: string, netOption: string) => {
     return http.get<Dashboard.CurrentInfo>(`/dashboard/current/${ioOption}/${netOption}`);
 };
 
+export const loadTopCPU = () => {
+    return http.get<Array<Dashboard.Process>>(`/dashboard/current/top/cpu`);
+};
+
+export const loadTopMem = () => {
+    return http.get<Array<Dashboard.Process>>(`/dashboard/current/top/mem`);
+};
+
 export const systemRestart = (operation: string) => {
     return http.post(`/dashboard/system/restart/${operation}`);
 };

--- a/frontend/src/views/home/index.vue
+++ b/frontend/src/views/home/index.vue
@@ -450,6 +450,14 @@ const currentChartInfo = reactive({
 
 const chartsOption = ref({ ioChart1: null, networkChart: null });
 
+const updateCurrentInfo = (data: Dashboard.CurrentInfo) => {
+    currentInfo.value = {
+        ...data,
+        topCPUItems: currentInfo.value.topCPUItems || [],
+        topMemItems: currentInfo.value.topMemItems || [],
+    };
+};
+
 const changeOption = async () => {
     isInit.value = true;
     loadData();
@@ -484,7 +492,7 @@ const onLoadBaseInfo = async (isInit: boolean, range: string) => {
     }
     const res = await loadBaseInfo(searchInfo.ioOption, searchInfo.netOption);
     baseInfo.value = res.data;
-    currentInfo.value = baseInfo.value.currentInfo;
+    updateCurrentInfo(baseInfo.value.currentInfo);
     onLoadCurrentInfo();
     isStatusInit.value = false;
     statusRef.value?.acceptParams(currentInfo.value, baseInfo.value);
@@ -584,7 +592,7 @@ const onLoadCurrentInfo = async () => {
         timeNetDatas.value.splice(0, 1);
     }
     loadData();
-    currentInfo.value = res.data;
+    updateCurrentInfo(res.data);
     statusRef.value?.acceptParams(currentInfo.value, baseInfo.value);
 };
 

--- a/frontend/src/views/home/status/index.vue
+++ b/frontend/src/views/home/status/index.vue
@@ -6,7 +6,6 @@
                 :teleported="false"
                 :width="320"
                 v-if="chartsOption['load']"
-                @show="onCpuPopoverShow"
                 @hide="onCpuPopoverHide"
             >
                 <el-descriptions :column="1" size="small">
@@ -21,12 +20,12 @@
                     </el-descriptions-item>
                 </el-descriptions>
 
-                <el-button link size="small" type="primary" class="float-left mb-2" @click="showTop = !showTop">
+                <el-button link size="small" type="primary" class="float-left mb-2" @click="toggleCpuTop">
                     {{ $t('home.cpuTop') }}
-                    <el-icon v-if="!showTop"><ArrowRight /></el-icon>
-                    <el-icon v-if="showTop"><ArrowDown /></el-icon>
+                    <el-icon v-if="!showCpuTop"><ArrowRight /></el-icon>
+                    <el-icon v-if="showCpuTop"><ArrowDown /></el-icon>
                 </el-button>
-                <ComplexTable v-if="showTop" :data="currentInfo.topCPUItems">
+                <ComplexTable v-if="showCpuTop" :data="currentInfo.topCPUItems">
                     <el-table-column :min-width="120" show-overflow-tooltip :label="$t('menu.process')" prop="name" />
                     <el-table-column :min-width="60" :label="$t('monitor.percent')" prop="percent">
                         <template #default="{ row }">{{ row.percent.toFixed(2) }}%</template>
@@ -57,7 +56,6 @@
                 :teleported="false"
                 :width="430"
                 v-if="chartsOption['cpu']"
-                @show="onCpuPopoverShow"
                 @hide="onCpuPopoverHide"
             >
                 <el-descriptions :title="baseInfo.cpuModelName" :column="2" size="small">
@@ -84,12 +82,12 @@
                     <el-button v-if="cpuShowAll" @click="cpuShowAll = false" icon="ArrowUp" link size="small" />
                 </div>
 
-                <el-button link size="small" type="primary" class="mt-2 mb-2" @click="showTop = !showTop">
+                <el-button link size="small" type="primary" class="mt-2 mb-2" @click="toggleCpuTop">
                     {{ $t('home.cpuTop') }}
-                    <el-icon v-if="!showTop"><ArrowRight /></el-icon>
-                    <el-icon v-if="showTop"><ArrowDown /></el-icon>
+                    <el-icon v-if="!showCpuTop"><ArrowRight /></el-icon>
+                    <el-icon v-if="showCpuTop"><ArrowDown /></el-icon>
                 </el-button>
-                <ComplexTable v-if="showTop" :data="currentInfo.topCPUItems">
+                <ComplexTable v-if="showCpuTop" :data="currentInfo.topCPUItems">
                     <el-table-column :min-width="120" show-overflow-tooltip :label="$t('menu.process')" prop="name" />
                     <el-table-column :min-width="60" :label="$t('monitor.percent')" prop="percent">
                         <template #default="{ row }">{{ row.percent.toFixed(2) }}%</template>
@@ -125,7 +123,6 @@
                 :teleported="false"
                 :width="480"
                 v-if="chartsOption['memory']"
-                @show="onMemPopoverShow"
                 @hide="onMemPopoverHide"
             >
                 <el-descriptions direction="vertical" :title="$t('home.mem')" class="ml-1" :column="4" size="small">
@@ -174,12 +171,12 @@
                     </el-descriptions-item>
                 </el-descriptions>
 
-                <el-button link size="small" type="primary" class="float-left mb-2" @click="showTop = !showTop">
+                <el-button link size="small" type="primary" class="float-left mb-2" @click="toggleMemTop">
                     {{ $t('home.memTop') }}
-                    <el-icon v-if="!showTop"><ArrowRight /></el-icon>
-                    <el-icon v-if="showTop"><ArrowDown /></el-icon>
+                    <el-icon v-if="!showMemTop"><ArrowRight /></el-icon>
+                    <el-icon v-if="showMemTop"><ArrowDown /></el-icon>
                 </el-button>
-                <ComplexTable v-if="showTop" :data="currentInfo.topMemItems">
+                <ComplexTable v-if="showMemTop" :data="currentInfo.topMemItems">
                     <el-table-column :min-width="120" show-overflow-tooltip :label="$t('menu.process')" prop="name" />
                     <el-table-column :min-width="100" :label="$t('monitor.memory')" prop="memory">
                         <template #default="{ row }">
@@ -431,7 +428,8 @@ const currentInfo = ref<Dashboard.CurrentInfo>({
 });
 
 const cpuShowAll = ref();
-const showTop = ref();
+const showCpuTop = ref(false);
+const showMemTop = ref(false);
 const killProcessID = ref();
 const confirmConfRef = ref();
 
@@ -541,30 +539,48 @@ function formatNumber(val: number) {
     return Number(val.toFixed(2));
 }
 
-const onCpuPopoverShow = async () => {
-    await loadTopCPUData();
-    if (cpuPopoverTimer) {
-        clearInterval(Number(cpuPopoverTimer));
+const toggleCpuTop = async () => {
+    showCpuTop.value = !showCpuTop.value;
+    if (showCpuTop.value) {
+        await loadTopCPUData();
+        if (cpuPopoverTimer) {
+            clearInterval(Number(cpuPopoverTimer));
+        }
+        cpuPopoverTimer = setInterval(loadTopCPUData, 5000);
+    } else {
+        if (cpuPopoverTimer) {
+            clearInterval(Number(cpuPopoverTimer));
+            cpuPopoverTimer = null;
+        }
     }
-    cpuPopoverTimer = setInterval(loadTopCPUData, 5000);
 };
 
 const onCpuPopoverHide = () => {
+    showCpuTop.value = false;
     if (cpuPopoverTimer) {
         clearInterval(Number(cpuPopoverTimer));
         cpuPopoverTimer = null;
     }
 };
 
-const onMemPopoverShow = async () => {
-    await loadTopMemData();
-    if (memPopoverTimer) {
-        clearInterval(Number(memPopoverTimer));
+const toggleMemTop = async () => {
+    showMemTop.value = !showMemTop.value;
+    if (showMemTop.value) {
+        await loadTopMemData();
+        if (memPopoverTimer) {
+            clearInterval(Number(memPopoverTimer));
+        }
+        memPopoverTimer = setInterval(loadTopMemData, 5000);
+    } else {
+        if (memPopoverTimer) {
+            clearInterval(Number(memPopoverTimer));
+            memPopoverTimer = null;
+        }
     }
-    memPopoverTimer = setInterval(loadTopMemData, 5000);
 };
 
 const onMemPopoverHide = () => {
+    showMemTop.value = false;
     if (memPopoverTimer) {
         clearInterval(Number(memPopoverTimer));
         memPopoverTimer = null;

--- a/frontend/src/views/home/status/index.vue
+++ b/frontend/src/views/home/status/index.vue
@@ -1,7 +1,14 @@
 <template>
     <div class="custom-row">
         <el-col :xs="6" :sm="6" :md="3" :lg="3" :xl="3" align="center">
-            <el-popover :hide-after="20" :teleported="false" :width="320" v-if="chartsOption['load']">
+            <el-popover
+                :hide-after="20"
+                :teleported="false"
+                :width="320"
+                v-if="chartsOption['load']"
+                @show="onCpuPopoverShow"
+                @hide="onCpuPopoverHide"
+            >
                 <el-descriptions :column="1" size="small">
                     <el-descriptions-item :label="$t('home.loadAverage', [1])">
                         {{ formatNumber(currentInfo.load1) }}
@@ -45,7 +52,14 @@
             <span class="input-help">{{ loadStatus(currentInfo.loadUsagePercent) }}</span>
         </el-col>
         <el-col :xs="6" :sm="6" :md="3" :lg="3" :xl="3">
-            <el-popover :hide-after="20" :teleported="false" :width="430" v-if="chartsOption['cpu']">
+            <el-popover
+                :hide-after="20"
+                :teleported="false"
+                :width="430"
+                v-if="chartsOption['cpu']"
+                @show="onCpuPopoverShow"
+                @hide="onCpuPopoverHide"
+            >
                 <el-descriptions :title="baseInfo.cpuModelName" :column="2" size="small">
                     <el-descriptions-item :label="$t('home.core')">
                         {{ baseInfo.cpuCores }}
@@ -106,7 +120,14 @@
             </div>
         </el-col>
         <el-col :xs="6" :sm="6" :md="3" :lg="3" :xl="3" align="center">
-            <el-popover :hide-after="20" :teleported="false" :width="480" v-if="chartsOption['memory']">
+            <el-popover
+                :hide-after="20"
+                :teleported="false"
+                :width="480"
+                v-if="chartsOption['memory']"
+                @show="onMemPopoverShow"
+                @hide="onMemPopoverHide"
+            >
                 <el-descriptions direction="vertical" :title="$t('home.mem')" class="ml-1" :column="4" size="small">
                     <el-descriptions-item :label-width="60" :label="$t('home.total')">
                         {{ computeSize(currentInfo.memoryTotal) }}
@@ -333,12 +354,18 @@
 import { Dashboard } from '@/api/interface/dashboard';
 import { computeSize } from '@/utils/util';
 import i18n from '@/lang';
-import { nextTick, ref } from 'vue';
+import { nextTick, onBeforeUnmount, ref } from 'vue';
 import { routerToFileWithPath, routerToName } from '@/utils/router';
 import { stopProcess } from '@/api/modules/process';
+import { loadTopCPU, loadTopMem } from '@/api/modules/dashboard';
 import { MsgSuccess } from '@/utils/message';
 const showMore = ref(false);
 const totalCount = ref();
+
+let cpuPopoverTimer: ReturnType<typeof setTimeout> | null = null;
+let memPopoverTimer: ReturnType<typeof setTimeout> | null = null;
+let cpuLoading = false;
+let memLoading = false;
 
 const baseInfo = ref<Dashboard.BaseInfo>({
     hostname: '',
@@ -513,6 +540,73 @@ const goGPU = () => {
 function formatNumber(val: number) {
     return Number(val.toFixed(2));
 }
+
+const onCpuPopoverShow = async () => {
+    await loadTopCPUData();
+    if (cpuPopoverTimer) {
+        clearInterval(Number(cpuPopoverTimer));
+    }
+    cpuPopoverTimer = setInterval(loadTopCPUData, 5000);
+};
+
+const onCpuPopoverHide = () => {
+    if (cpuPopoverTimer) {
+        clearInterval(Number(cpuPopoverTimer));
+        cpuPopoverTimer = null;
+    }
+};
+
+const onMemPopoverShow = async () => {
+    await loadTopMemData();
+    if (memPopoverTimer) {
+        clearInterval(Number(memPopoverTimer));
+    }
+    memPopoverTimer = setInterval(loadTopMemData, 5000);
+};
+
+const onMemPopoverHide = () => {
+    if (memPopoverTimer) {
+        clearInterval(Number(memPopoverTimer));
+        memPopoverTimer = null;
+    }
+};
+
+const loadTopCPUData = async () => {
+    if (cpuLoading) return;
+    cpuLoading = true;
+    try {
+        const res = await loadTopCPU();
+        currentInfo.value.topCPUItems = res.data || [];
+    } catch (_error) {
+        // ignore load errors
+    } finally {
+        cpuLoading = false;
+    }
+};
+
+const loadTopMemData = async () => {
+    if (memLoading) return;
+    memLoading = true;
+    try {
+        const res = await loadTopMem();
+        currentInfo.value.topMemItems = res.data || [];
+    } catch (_error) {
+        // ignore load errors
+    } finally {
+        memLoading = false;
+    }
+};
+
+onBeforeUnmount(() => {
+    if (cpuPopoverTimer) {
+        clearInterval(Number(cpuPopoverTimer));
+        cpuPopoverTimer = null;
+    }
+    if (memPopoverTimer) {
+        clearInterval(Number(memPopoverTimer));
+        memPopoverTimer = null;
+    }
+});
 
 defineExpose({
     acceptParams,


### PR DESCRIPTION
#### What this PR does / why we need it?
<img width="711" height="621" alt="image" src="https://github.com/user-attachments/assets/47227099-2ac2-4b73-b819-b61d98044194" />
官网这个地方新加的 top5 cpu/mem 使用的进程通常对用户来说，如果不主动查看则默认不可见
这两个新数据相当吃 cpu 和 io, 执行两个函数大概在我的机器上有 100ms 的时间开销

#### Summary of your change
拆分接口，/api/v2/dashboard/current/all/all 不再拉取 top5 cpu 和 top5 mem。
当用户鼠标移动到 cpu 内存，去查看这个弹窗的数据时，才会启动定时器定时拉取对应的数据。 无焦点停止定时拉取。
优化后剩余的性能数据获取逻辑，每次执行只有 1ms


#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.