### PR TITLE
fix: adjust WebSocket buffer sizes in terminal and host API

### DIFF
--- a/agent/app/api/v2/terminal.go
+++ b/agent/app/api/v2/terminal.go
@@ -228,8 +228,8 @@ func wshandleError(ws *websocket.Conn, err error) bool {
 }
 
 var upGrader = websocket.Upgrader{
-	ReadBufferSize:  1024,
-	WriteBufferSize: 1024 * 1024 * 10,
+	ReadBufferSize:  4096,
+	WriteBufferSize: 16384,
 	CheckOrigin: func(r *http.Request) bool {
 		return true
 	},

--- a/core/app/api/v2/host.go
+++ b/core/app/api/v2/host.go
@@ -327,8 +327,8 @@ func (b *BaseApi) WsSsh(c *gin.Context) {
 }
 
 var upGrader = websocket.Upgrader{
-	ReadBufferSize:  1024,
-	WriteBufferSize: 1024 * 1024 * 10,
+	ReadBufferSize:  4096,
+	WriteBufferSize: 16384,
 	CheckOrigin: func(r *http.Request) bool {
 		return true
 	},


### PR DESCRIPTION
#### What this PR does / why we need it?
websocket 给 write 初始化分配10M buffer 太奢侈了，用不上还吃内存
#### Summary of your change
降低 writebuffersize到一个相对保守的值, 把 readzise 换成默认值 4096，终端功能可以依然正常行使功能

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.