### PR TITLE
fix: improve applist loading by using JSON decoder from file stream

### DIFF
--- a/agent/app/service/app.go
+++ b/agent/app/service/app.go
@@ -862,13 +862,15 @@ func getAppList() (*dto.AppList, error) {
 		return nil, err
 	}
 	listFile := filepath.Join(global.Dir.ResourceDir, "1panel.json")
-	content, err := os.ReadFile(listFile)
+	file, err := os.Open(listFile)
 	if err != nil {
 		return nil, err
 	}
-	if err = json.Unmarshal(content, list); err != nil {
+	defer file.Close()
+	if err = json.NewDecoder(file).Decode(list); err != nil {
 		return nil, err
 	}
+
 	return list, nil
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it?
<img width="445" height="436" alt="image" src="https://github.com/user-attachments/assets/38a9246b-caee-4bcf-ac40-a59ac4292814" />

直接读取文件时,会把文件内容拷贝到 content ，此时会有 2m 内存 (应用商店信息的json文件大小)，然后内存中的 content再被反序列化内容。
可以直接用 decoder 一步读文件并反序列化，省掉这个拷贝操作。节约 2m 内存

#### Summary of your change
更换流 decoder 方法，直接让 decoder 读文件解析出内容。节约流程中在堆上占用 2m 的内存, 解析流程不变。

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.