### PR TITLE
feat: Implement dashboard caching and refresh functionality

### DIFF
--- a/frontend/src/layout/components/Sidebar/components/Collapse.vue
+++ b/frontend/src/layout/components/Sidebar/components/Collapse.vue
@@ -238,6 +238,10 @@ const logout = () => {
     })
         .then(async () => {
             await logOutApi();
+            sessionStorage.removeItem('dashboardCache');
+            localStorage.removeItem('dashboardCache');
+            sessionStorage.removeItem('upgradeChecked');
+            localStorage.removeItem('upgradeChecked');
             router.push({ name: 'entrance', params: { code: globalStore.entrance } });
             globalStore.setLogStatus(false);
             MsgSuccess(i18n.global.t('commons.msg.operationSuccess'));

--- a/frontend/src/utils/dashboardCache.ts
+++ b/frontend/src/utils/dashboardCache.ts
@@ -1,0 +1,61 @@
+const DASHBOARD_CACHE_KEY = 'dashboardCache';
+
+type CacheEntry = {
+    value: any;
+    expireAt: number;
+};
+
+const readCache = (): Record<string, CacheEntry> | null => {
+    try {
+        const cacheRaw = localStorage.getItem(DASHBOARD_CACHE_KEY);
+        return cacheRaw ? JSON.parse(cacheRaw) : {};
+    } catch {
+        return null;
+    }
+};
+
+export const getDashboardCache = (key: string) => {
+    const cache = readCache();
+    if (!cache) return null;
+    const entry = cache[key];
+    if (entry && entry.expireAt > Date.now()) {
+        return entry.value;
+    }
+    return null;
+};
+
+export const setDashboardCache = (key: string, value: any, ttl: number) => {
+    try {
+        const cacheRaw = localStorage.getItem(DASHBOARD_CACHE_KEY);
+        const cache = cacheRaw ? JSON.parse(cacheRaw) : {};
+        cache[key] = {
+            value,
+            expireAt: Date.now() + ttl,
+        };
+        localStorage.setItem(DASHBOARD_CACHE_KEY, JSON.stringify(cache));
+    } catch {
+        localStorage.removeItem(DASHBOARD_CACHE_KEY);
+    }
+};
+
+export const clearDashboardCache = () => {
+    localStorage.removeItem(DASHBOARD_CACHE_KEY);
+};
+
+export const clearDashboardCacheByPrefix = (prefixes: string[]) => {
+    try {
+        const cacheRaw = localStorage.getItem(DASHBOARD_CACHE_KEY);
+        if (!cacheRaw) return;
+        const cache = JSON.parse(cacheRaw);
+        Object.keys(cache).forEach((key: string) => {
+            if (prefixes.some((prefix) => key.startsWith(prefix))) {
+                delete cache[key];
+            }
+        });
+        localStorage.setItem(DASHBOARD_CACHE_KEY, JSON.stringify(cache));
+    } catch {
+        clearDashboardCache();
+    }
+};
+
+export { DASHBOARD_CACHE_KEY };

--- a/frontend/src/views/home/app/index.vue
+++ b/frontend/src/views/home/app/index.vue
@@ -196,62 +196,19 @@ import { useRouter } from 'vue-router';
 import { jumpToPath } from '@/utils/util';
 import { jumpToInstall } from '@/utils/app';
 import { routerToFileWithPath, routerToNameWithQuery } from '@/utils/router';
+import { clearDashboardCacheByPrefix, getDashboardCache, setDashboardCache } from '@/utils/dashboardCache';
 
 const router = useRouter();
 const globalStore = GlobalStore();
 
-const DASHBOARD_CACHE_KEY = 'dashboardCache';
 const DASHBOARD_CACHE_TTL = {
-    launcherOption: 60 * 60 * 1000,
-    launcher: 60 * 60 * 1000,
-    systemIP: 60 * 60 * 1000,
-};
-
-const getDashboardCache = (key: string) => {
-    try {
-        const cacheRaw = localStorage.getItem(DASHBOARD_CACHE_KEY);
-        if (!cacheRaw) return null;
-        const cache = JSON.parse(cacheRaw);
-        const entry = cache[key];
-        if (entry && entry.expireAt > Date.now()) {
-            return entry.value;
-        }
-    } catch {}
-    return null;
-};
-
-const setDashboardCache = (key: string, value: any, ttl: number) => {
-    try {
-        const cacheRaw = localStorage.getItem(DASHBOARD_CACHE_KEY);
-        const cache = cacheRaw ? JSON.parse(cacheRaw) : {};
-        cache[key] = {
-            value,
-            expireAt: Date.now() + ttl,
-        };
-        localStorage.setItem(DASHBOARD_CACHE_KEY, JSON.stringify(cache));
-    } catch {}
+    launcherOption: 5 * 60 * 1000,
+    launcher: 10 * 60 * 1000,
+    systemIP: 10 * 60 * 1000,
 };
 
 const clearLauncherCache = () => {
-    try {
-        const cacheRaw = localStorage.getItem(DASHBOARD_CACHE_KEY);
-        if (!cacheRaw) return;
-        const cache = JSON.parse(cacheRaw);
-        Object.keys(cache).forEach((key: string) => {
-            if (key.startsWith('appLauncherOption-')) {
-                delete cache[key];
-            }
-            if (key === 'appLauncher') {
-                delete cache[key];
-            }
-            if (key === 'systemIP') {
-                delete cache[key];
-            }
-        });
-        localStorage.setItem(DASHBOARD_CACHE_KEY, JSON.stringify(cache));
-    } catch {
-        localStorage.removeItem(DASHBOARD_CACHE_KEY);
-    }
+    clearDashboardCacheByPrefix(['appLauncherOption-', 'appLauncher', 'systemIP']);
 };
 
 let loading = ref(false);

--- a/frontend/src/views/home/app/index.vue
+++ b/frontend/src/views/home/app/index.vue
@@ -1,6 +1,11 @@
 <template>
     <div>
-        <CardWithHeader :header="$t('app.app')" class="card-interval" v-loading="loading">
+        <CardWithHeader
+            :header="$t('app.app')"
+            class="card-interval"
+            v-loading="loading"
+            @mouseenter="refreshLauncherOnHover"
+        >
             <template #header-r>
                 <el-button class="h-button-setting" link icon="Refresh" @click="refreshLauncher" />
                 <el-popover placement="left" :width="226" trigger="click">
@@ -197,9 +202,9 @@ const globalStore = GlobalStore();
 
 const DASHBOARD_CACHE_KEY = 'dashboardCache';
 const DASHBOARD_CACHE_TTL = {
-    launcherOption: 5 * 60 * 1000,
-    launcher: 10 * 60 * 1000,
-    systemIP: 10 * 60 * 1000,
+    launcherOption: 60 * 60 * 1000,
+    launcher: 60 * 60 * 1000,
+    systemIP: 60 * 60 * 1000,
 };
 
 const getDashboardCache = (key: string) => {
@@ -253,12 +258,17 @@ let loading = ref(false);
 let apps = ref([]);
 const options = ref([]);
 const filter = ref();
+const launcherFromCache = ref(false);
+const launcherOptionFromCache = ref(false);
+const systemIPFromCache = ref(false);
+const hasRefreshedLauncherOnHover = ref(false);
 const mobile = computed(() => {
     return globalStore.isMobile();
 });
 const defaultLink = ref('');
 
 const acceptParams = (): void => {
+    hasRefreshedLauncherOnHover.value = false;
     search();
     loadOption();
     getConfig();
@@ -270,11 +280,12 @@ const goInstall = (key: string, type: string) => {
     }
 };
 
-const search = async () => {
+const search = async (force?: boolean) => {
     loading.value = true;
-    const cache = getDashboardCache('appLauncher');
+    const cache = force ? null : getDashboardCache('appLauncher');
     if (cache !== null) {
         apps.value = cache;
+        launcherFromCache.value = true;
         for (const item of apps.value) {
             if (item.detail && item.detail.length !== 0) {
                 item.currentRow = item.detail[0];
@@ -287,6 +298,7 @@ const search = async () => {
         .then((res) => {
             loading.value = false;
             apps.value = res.data;
+            launcherFromCache.value = false;
             for (const item of apps.value) {
                 if (item.detail && item.detail.length !== 0) {
                     item.currentRow = item.detail[0];
@@ -318,18 +330,18 @@ const toLink = (link: string) => {
     window.open(link, '_blank');
 };
 
-const getConfig = async () => {
+const getConfig = async (force?: boolean) => {
     try {
-        const cache = getDashboardCache('systemIP');
+        const cache = force ? null : getDashboardCache('systemIP');
         if (cache !== null) {
             defaultLink.value = cache;
+            systemIPFromCache.value = true;
             return;
         }
         const res = await getAgentSettingByKey('SystemIP');
-        if (res.data != '') {
-            defaultLink.value = res.data;
-            setDashboardCache('systemIP', res.data, DASHBOARD_CACHE_TTL.systemIP);
-        }
+        defaultLink.value = res.data || '';
+        systemIPFromCache.value = false;
+        setDashboardCache('systemIP', defaultLink.value, DASHBOARD_CACHE_TTL.systemIP);
     } catch (error) {}
 };
 
@@ -361,21 +373,33 @@ const onOperate = async (operation: string, row: any) => {
     });
 };
 
-const loadOption = async () => {
+const loadOption = async (force?: boolean) => {
     const cacheKey = `appLauncherOption-${filter.value || ''}`;
-    const cache = getDashboardCache(cacheKey);
+    const cache = force ? null : getDashboardCache(cacheKey);
     if (cache !== null) {
         options.value = cache;
+        launcherOptionFromCache.value = true;
         return;
     }
     const res = await loadAppLauncherOption(filter.value || '');
     options.value = res.data || [];
+    launcherOptionFromCache.value = false;
     setDashboardCache(cacheKey, options.value, DASHBOARD_CACHE_TTL.launcherOption);
 };
 
 const refreshLauncher = async () => {
     clearLauncherCache();
-    await Promise.allSettled([loadOption(), search()]);
+    hasRefreshedLauncherOnHover.value = false;
+    await Promise.allSettled([loadOption(true), search(true), getConfig(true)]);
+};
+
+const refreshLauncherOnHover = async () => {
+    if (hasRefreshedLauncherOnHover.value) return;
+    if (!launcherFromCache.value && !launcherOptionFromCache.value && !systemIPFromCache.value) return;
+    hasRefreshedLauncherOnHover.value = true;
+    await loadOption(true);
+    await search(true);
+    await getConfig(true);
 };
 
 defineExpose({

--- a/frontend/src/views/home/app/index.vue
+++ b/frontend/src/views/home/app/index.vue
@@ -2,6 +2,7 @@
     <div>
         <CardWithHeader :header="$t('app.app')" class="card-interval" v-loading="loading">
             <template #header-r>
+                <el-button class="h-button-setting" link icon="Refresh" @click="refreshLauncher" />
                 <el-popover placement="left" :width="226" trigger="click">
                     <el-input size="small" v-model="filter" clearable @input="loadOption()" />
                     <el-table :show-header="false" :data="options" max-height="150px">
@@ -185,7 +186,7 @@ import { changeLauncherStatus, loadAppLauncher, loadAppLauncherOption } from '@/
 import i18n from '@/lang';
 import { GlobalStore } from '@/store';
 import { MsgSuccess } from '@/utils/message';
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 import { useRouter } from 'vue-router';
 import { jumpToPath } from '@/utils/util';
 import { jumpToInstall } from '@/utils/app';
@@ -193,6 +194,60 @@ import { routerToFileWithPath, routerToNameWithQuery } from '@/utils/router';
 
 const router = useRouter();
 const globalStore = GlobalStore();
+
+const DASHBOARD_CACHE_KEY = 'dashboardCache';
+const DASHBOARD_CACHE_TTL = {
+    launcherOption: 5 * 60 * 1000,
+    launcher: 10 * 60 * 1000,
+    systemIP: 10 * 60 * 1000,
+};
+
+const getDashboardCache = (key: string) => {
+    try {
+        const cacheRaw = localStorage.getItem(DASHBOARD_CACHE_KEY);
+        if (!cacheRaw) return null;
+        const cache = JSON.parse(cacheRaw);
+        const entry = cache[key];
+        if (entry && entry.expireAt > Date.now()) {
+            return entry.value;
+        }
+    } catch {}
+    return null;
+};
+
+const setDashboardCache = (key: string, value: any, ttl: number) => {
+    try {
+        const cacheRaw = localStorage.getItem(DASHBOARD_CACHE_KEY);
+        const cache = cacheRaw ? JSON.parse(cacheRaw) : {};
+        cache[key] = {
+            value,
+            expireAt: Date.now() + ttl,
+        };
+        localStorage.setItem(DASHBOARD_CACHE_KEY, JSON.stringify(cache));
+    } catch {}
+};
+
+const clearLauncherCache = () => {
+    try {
+        const cacheRaw = localStorage.getItem(DASHBOARD_CACHE_KEY);
+        if (!cacheRaw) return;
+        const cache = JSON.parse(cacheRaw);
+        Object.keys(cache).forEach((key: string) => {
+            if (key.startsWith('appLauncherOption-')) {
+                delete cache[key];
+            }
+            if (key === 'appLauncher') {
+                delete cache[key];
+            }
+            if (key === 'systemIP') {
+                delete cache[key];
+            }
+        });
+        localStorage.setItem(DASHBOARD_CACHE_KEY, JSON.stringify(cache));
+    } catch {
+        localStorage.removeItem(DASHBOARD_CACHE_KEY);
+    }
+};
 
 let loading = ref(false);
 let apps = ref([]);
@@ -217,6 +272,17 @@ const goInstall = (key: string, type: string) => {
 
 const search = async () => {
     loading.value = true;
+    const cache = getDashboardCache('appLauncher');
+    if (cache !== null) {
+        apps.value = cache;
+        for (const item of apps.value) {
+            if (item.detail && item.detail.length !== 0) {
+                item.currentRow = item.detail[0];
+            }
+        }
+        loading.value = false;
+        return;
+    }
     await loadAppLauncher()
         .then((res) => {
             loading.value = false;
@@ -226,6 +292,7 @@ const search = async () => {
                     item.currentRow = item.detail[0];
                 }
             }
+            setDashboardCache('appLauncher', apps.value, DASHBOARD_CACHE_TTL.launcher);
         })
         .finally(() => {
             loading.value = false;
@@ -238,7 +305,9 @@ const onChangeStatus = async (row: any) => {
         .then(() => {
             loading.value = false;
             MsgSuccess(i18n.global.t('commons.msg.operationSuccess'));
+            clearLauncherCache();
             search();
+            loadOption();
         })
         .catch(() => {
             loading.value = false;
@@ -251,9 +320,15 @@ const toLink = (link: string) => {
 
 const getConfig = async () => {
     try {
+        const cache = getDashboardCache('systemIP');
+        if (cache !== null) {
+            defaultLink.value = cache;
+            return;
+        }
         const res = await getAgentSettingByKey('SystemIP');
         if (res.data != '') {
             defaultLink.value = res.data;
+            setDashboardCache('systemIP', res.data, DASHBOARD_CACHE_TTL.systemIP);
         }
     } catch (error) {}
 };
@@ -287,8 +362,20 @@ const onOperate = async (operation: string, row: any) => {
 };
 
 const loadOption = async () => {
+    const cacheKey = `appLauncherOption-${filter.value || ''}`;
+    const cache = getDashboardCache(cacheKey);
+    if (cache !== null) {
+        options.value = cache;
+        return;
+    }
     const res = await loadAppLauncherOption(filter.value || '');
     options.value = res.data || [];
+    setDashboardCache(cacheKey, options.value, DASHBOARD_CACHE_TTL.launcherOption);
+};
+
+const refreshLauncher = async () => {
+    clearLauncherCache();
+    await Promise.allSettled([loadOption(), search()]);
 };
 
 defineExpose({

--- a/frontend/src/views/home/index.vue
+++ b/frontend/src/views/home/index.vue
@@ -77,6 +77,7 @@
                     :header="$t('menu.monitor')"
                     class="card-interval chart-card"
                     v-loading="!chartsOption['networkChart']"
+                    @mouseenter="refreshOptionsOnHover"
                 >
                     <template #header-r>
                         <el-radio-group
@@ -340,11 +341,9 @@ const globalStore = GlobalStore();
 
 const DASHBOARD_CACHE_KEY = 'dashboardCache';
 const DASHBOARD_CACHE_TTL = {
-    baseInfo: 90 * 1000,
-    simpleNodes: 60 * 1000,
-    safeStatus: 90 * 1000,
-    netOptions: 10 * 60 * 1000,
-    ioOptions: 10 * 60 * 1000,
+    safeStatus: 10 * 60 * 1000,
+    netOptions: 60 * 60 * 1000,
+    ioOptions: 60 * 60 * 1000,
 };
 const UPGRADE_CHECK_KEY = 'upgradeChecked';
 const UPGRADE_CHECK_EXPIRE = 24 * 60 * 60 * 1000;
@@ -376,6 +375,9 @@ const timeNetDatas = ref<Array<string>>([]);
 const simpleNodes = ref([]);
 const ioOptions = ref();
 const netOptions = ref();
+const netOptionsFromCache = ref(false);
+const ioOptionsFromCache = ref(false);
+const hasRefreshedOptionsOnHover = ref(false);
 
 const licenseRef = ref();
 const quickJumpRef = ref();
@@ -515,28 +517,24 @@ const applyDefaultNetOption = () => {
     }
 };
 
-const onLoadNetworkOptions = async () => {
-    const cache = getDashboardCache('netOptions');
+const onLoadNetworkOptions = async (force?: boolean) => {
+    const cache = force ? null : getDashboardCache('netOptions');
     if (cache !== null) {
         netOptions.value = cache;
+        netOptionsFromCache.value = true;
         applyDefaultNetOption();
         return;
     }
     const res = await getNetworkOptions();
     netOptions.value = res.data;
+    netOptionsFromCache.value = false;
     setDashboardCache('netOptions', res.data, DASHBOARD_CACHE_TTL.netOptions);
     applyDefaultNetOption();
 };
 
 const onLoadSimpleNode = async () => {
-    const cache = getDashboardCache('simpleNodes');
-    if (cache !== null) {
-        simpleNodes.value = cache;
-        return;
-    }
     const res = await listAllSimpleNodes();
     simpleNodes.value = res.data || [];
-    setDashboardCache('simpleNodes', simpleNodes.value, DASHBOARD_CACHE_TTL.simpleNodes);
 };
 
 const applyDefaultIOOption = () => {
@@ -550,15 +548,17 @@ const applyDefaultIOOption = () => {
     }
 };
 
-const onLoadIOOptions = async () => {
-    const cache = getDashboardCache('ioOptions');
+const onLoadIOOptions = async (force?: boolean) => {
+    const cache = force ? null : getDashboardCache('ioOptions');
     if (cache !== null) {
         ioOptions.value = cache;
+        ioOptionsFromCache.value = true;
         applyDefaultIOOption();
         return;
     }
     const res = await getIOOptions();
     ioOptions.value = res.data;
+    ioOptionsFromCache.value = false;
     setDashboardCache('ioOptions', ioOptions.value, DASHBOARD_CACHE_TTL.ioOptions);
     applyDefaultIOOption();
 };
@@ -573,14 +573,8 @@ const onLoadBaseInfo = async (isInit: boolean, range: string) => {
         netBytesRecvs.value = [];
         timeNetDatas.value = [];
     }
-    const cacheKey = `baseInfo-${searchInfo.ioOption}-${searchInfo.netOption}`;
-    let baseData = getDashboardCache(cacheKey);
-    if (!baseData) {
-        const res = await loadBaseInfo(searchInfo.ioOption, searchInfo.netOption);
-        baseData = res.data;
-        setDashboardCache(cacheKey, baseData, DASHBOARD_CACHE_TTL.baseInfo);
-    }
-    baseInfo.value = baseData;
+    const res = await loadBaseInfo(searchInfo.ioOption, searchInfo.netOption);
+    baseInfo.value = res.data;
     updateCurrentInfo(baseInfo.value.currentInfo);
     onLoadCurrentInfo();
     isStatusInit.value = false;
@@ -622,9 +616,10 @@ const toggleSensitiveInfo = () => {
 const refreshDashboard = async () => {
     clearDashboardCache();
     localStorage.removeItem(UPGRADE_CHECK_KEY);
+    hasRefreshedOptionsOnHover.value = false;
     await onLoadBaseInfo(false, 'all');
-    await Promise.allSettled([onLoadSimpleNode(), onLoadNetworkOptions(), onLoadIOOptions(), loadSafeStatus()]);
-    loadUpgradeStatus();
+    await Promise.allSettled([onLoadSimpleNode(), onLoadNetworkOptions(true), onLoadIOOptions(true), loadSafeStatus()]);
+    await loadUpgradeStatus();
 };
 
 const jumpPanel = (row: any) => {
@@ -818,6 +813,18 @@ const toUpload = () => {
     licenseRef.value.acceptParams();
 };
 
+const refreshOptionsOnHover = async () => {
+    if (hasRefreshedOptionsOnHover.value) return;
+    if (!netOptionsFromCache.value && !ioOptionsFromCache.value) return;
+    hasRefreshedOptionsOnHover.value = true;
+    if (netOptionsFromCache.value) {
+        await onLoadNetworkOptions(true);
+    }
+    if (ioOptionsFromCache.value) {
+        await onLoadIOOptions(true);
+    }
+};
+
 const scheduleDeferredFetch = () => {
     setTimeout(() => {
         onLoadSimpleNode();
@@ -836,6 +843,7 @@ const scheduleDeferredFetch = () => {
 const fetchData = async () => {
     window.addEventListener('focus', onFocus);
     window.addEventListener('blur', onBlur);
+    hasRefreshedOptionsOnHover.value = false;
     await loadSafeStatus();
     await onLoadBaseInfo(true, 'all');
     scheduleDeferredFetch();

--- a/frontend/src/views/home/index.vue
+++ b/frontend/src/views/home/index.vue
@@ -173,6 +173,7 @@
                     <el-carousel-item key="systemInfo">
                         <CardWithHeader :header="$t('home.systemInfo')">
                             <template #header-r>
+                                <el-button class="h-button-setting" @click="refreshDashboard" link icon="Refresh" />
                                 <el-button
                                     class="h-button-setting"
                                     @click="toggleSensitiveInfo"
@@ -337,6 +338,17 @@ import { getWelcomePage } from '@/api/modules/auth';
 const router = useRouter();
 const globalStore = GlobalStore();
 
+const DASHBOARD_CACHE_KEY = 'dashboardCache';
+const DASHBOARD_CACHE_TTL = {
+    baseInfo: 90 * 1000,
+    simpleNodes: 60 * 1000,
+    safeStatus: 90 * 1000,
+    netOptions: 10 * 60 * 1000,
+    ioOptions: 10 * 60 * 1000,
+};
+const UPGRADE_CHECK_KEY = 'upgradeChecked';
+const UPGRADE_CHECK_EXPIRE = 24 * 60 * 60 * 1000;
+
 const statusRef = ref();
 const appRef = ref();
 
@@ -450,6 +462,35 @@ const currentChartInfo = reactive({
 
 const chartsOption = ref({ ioChart1: null, networkChart: null });
 
+const getDashboardCache = (key: string) => {
+    try {
+        const cacheRaw = localStorage.getItem(DASHBOARD_CACHE_KEY);
+        if (!cacheRaw) return null;
+        const cache = JSON.parse(cacheRaw);
+        const entry = cache[key];
+        if (entry && entry.expireAt > Date.now()) {
+            return entry.value;
+        }
+    } catch {}
+    return null;
+};
+
+const setDashboardCache = (key: string, value: any, ttl: number) => {
+    try {
+        const cacheRaw = localStorage.getItem(DASHBOARD_CACHE_KEY);
+        const cache = cacheRaw ? JSON.parse(cacheRaw) : {};
+        cache[key] = {
+            value,
+            expireAt: Date.now() + ttl,
+        };
+        localStorage.setItem(DASHBOARD_CACHE_KEY, JSON.stringify(cache));
+    } catch {}
+};
+
+const clearDashboardCache = () => {
+    localStorage.removeItem(DASHBOARD_CACHE_KEY);
+};
+
 const updateCurrentInfo = (data: Dashboard.CurrentInfo) => {
     currentInfo.value = {
         ...data,
@@ -463,21 +504,63 @@ const changeOption = async () => {
     loadData();
 };
 
+const applyDefaultNetOption = () => {
+    if (!netOptions.value || netOptions.value.length === 0) return;
+    const defaultNet = globalStore.defaultNetwork || netOptions.value[0];
+    if (defaultNet && searchInfo.netOption !== defaultNet) {
+        searchInfo.netOption = defaultNet;
+        if (!isStatusInit.value) {
+            onLoadBaseInfo(false, 'network');
+        }
+    }
+};
+
 const onLoadNetworkOptions = async () => {
+    const cache = getDashboardCache('netOptions');
+    if (cache !== null) {
+        netOptions.value = cache;
+        applyDefaultNetOption();
+        return;
+    }
     const res = await getNetworkOptions();
     netOptions.value = res.data;
-    searchInfo.netOption = globalStore.defaultNetwork || (netOptions.value && netOptions.value[0]);
+    setDashboardCache('netOptions', res.data, DASHBOARD_CACHE_TTL.netOptions);
+    applyDefaultNetOption();
 };
 
 const onLoadSimpleNode = async () => {
+    const cache = getDashboardCache('simpleNodes');
+    if (cache !== null) {
+        simpleNodes.value = cache;
+        return;
+    }
     const res = await listAllSimpleNodes();
     simpleNodes.value = res.data || [];
+    setDashboardCache('simpleNodes', simpleNodes.value, DASHBOARD_CACHE_TTL.simpleNodes);
+};
+
+const applyDefaultIOOption = () => {
+    if (!ioOptions.value || ioOptions.value.length === 0) return;
+    const defaultIO = globalStore.defaultIO || ioOptions.value[0];
+    if (defaultIO && searchInfo.ioOption !== defaultIO) {
+        searchInfo.ioOption = defaultIO;
+        if (!isStatusInit.value) {
+            onLoadBaseInfo(false, 'io');
+        }
+    }
 };
 
 const onLoadIOOptions = async () => {
+    const cache = getDashboardCache('ioOptions');
+    if (cache !== null) {
+        ioOptions.value = cache;
+        applyDefaultIOOption();
+        return;
+    }
     const res = await getIOOptions();
     ioOptions.value = res.data;
-    searchInfo.ioOption = globalStore.defaultIO || (ioOptions.value && ioOptions.value[0]);
+    setDashboardCache('ioOptions', ioOptions.value, DASHBOARD_CACHE_TTL.ioOptions);
+    applyDefaultIOOption();
 };
 
 const onLoadBaseInfo = async (isInit: boolean, range: string) => {
@@ -490,8 +573,14 @@ const onLoadBaseInfo = async (isInit: boolean, range: string) => {
         netBytesRecvs.value = [];
         timeNetDatas.value = [];
     }
-    const res = await loadBaseInfo(searchInfo.ioOption, searchInfo.netOption);
-    baseInfo.value = res.data;
+    const cacheKey = `baseInfo-${searchInfo.ioOption}-${searchInfo.netOption}`;
+    let baseData = getDashboardCache(cacheKey);
+    if (!baseData) {
+        const res = await loadBaseInfo(searchInfo.ioOption, searchInfo.netOption);
+        baseData = res.data;
+        setDashboardCache(cacheKey, baseData, DASHBOARD_CACHE_TTL.baseInfo);
+    }
+    baseInfo.value = baseData;
     updateCurrentInfo(baseInfo.value.currentInfo);
     onLoadCurrentInfo();
     isStatusInit.value = false;
@@ -528,6 +617,14 @@ const showSimpleNode = () => {
 
 const toggleSensitiveInfo = () => {
     showSensitiveInfo.value = !showSensitiveInfo.value;
+};
+
+const refreshDashboard = async () => {
+    clearDashboardCache();
+    localStorage.removeItem(UPGRADE_CHECK_KEY);
+    await onLoadBaseInfo(false, 'all');
+    await Promise.allSettled([onLoadSimpleNode(), onLoadNetworkOptions(), onLoadIOOptions(), loadSafeStatus()]);
+    loadUpgradeStatus();
 };
 
 const jumpPanel = (row: any) => {
@@ -670,17 +767,26 @@ const hideEntrance = () => {
 };
 
 const loadUpgradeStatus = async () => {
+    const checkedAt = Number(localStorage.getItem(UPGRADE_CHECK_KEY));
+    if (checkedAt && Date.now() - checkedAt < UPGRADE_CHECK_EXPIRE) return;
     const res = await loadUpgradeInfo();
     if (res && (res.data.testVersion || res.data.newVersion || res.data.latestVersion)) {
         globalStore.hasNewVersion = true;
     } else {
         globalStore.hasNewVersion = false;
     }
+    localStorage.setItem(UPGRADE_CHECK_KEY, Date.now().toString());
 };
 
 const loadSafeStatus = async () => {
+    const cache = getDashboardCache('safeStatus');
+    if (cache !== null) {
+        isSafety.value = cache;
+        return;
+    }
     const res = await getSettingInfo();
     isSafety.value = res.data.securityEntrance;
+    setDashboardCache('safeStatus', isSafety.value, DASHBOARD_CACHE_TTL.safeStatus);
 };
 
 const loadSource = (row: any) => {
@@ -712,15 +818,27 @@ const toUpload = () => {
     licenseRef.value.acceptParams();
 };
 
-const fetchData = () => {
+const scheduleDeferredFetch = () => {
+    setTimeout(() => {
+        onLoadSimpleNode();
+    }, 200);
+    setTimeout(() => {
+        onLoadNetworkOptions();
+    }, 400);
+    setTimeout(() => {
+        onLoadIOOptions();
+    }, 600);
+    setTimeout(() => {
+        loadUpgradeStatus();
+    }, 800);
+};
+
+const fetchData = async () => {
     window.addEventListener('focus', onFocus);
     window.addEventListener('blur', onBlur);
-    loadSafeStatus();
-    loadUpgradeStatus();
-    onLoadNetworkOptions();
-    onLoadIOOptions();
-    onLoadBaseInfo(true, 'all');
-    onLoadSimpleNode();
+    await loadSafeStatus();
+    await onLoadBaseInfo(true, 'all');
+    scheduleDeferredFetch();
 };
 
 const loadWelcome = async () => {

--- a/frontend/src/views/home/index.vue
+++ b/frontend/src/views/home/index.vue
@@ -336,10 +336,10 @@ import { GlobalStore } from '@/store';
 import { storeToRefs } from 'pinia';
 import { routerToFileWithPath, routerToPath } from '@/utils/router';
 import { getWelcomePage } from '@/api/modules/auth';
+import { clearDashboardCache, getDashboardCache, setDashboardCache } from '@/utils/dashboardCache';
 const router = useRouter();
 const globalStore = GlobalStore();
 
-const DASHBOARD_CACHE_KEY = 'dashboardCache';
 const DASHBOARD_CACHE_TTL = {
     safeStatus: 10 * 60 * 1000,
     netOptions: 60 * 60 * 1000,
@@ -463,35 +463,6 @@ const currentChartInfo = reactive({
 });
 
 const chartsOption = ref({ ioChart1: null, networkChart: null });
-
-const getDashboardCache = (key: string) => {
-    try {
-        const cacheRaw = localStorage.getItem(DASHBOARD_CACHE_KEY);
-        if (!cacheRaw) return null;
-        const cache = JSON.parse(cacheRaw);
-        const entry = cache[key];
-        if (entry && entry.expireAt > Date.now()) {
-            return entry.value;
-        }
-    } catch {}
-    return null;
-};
-
-const setDashboardCache = (key: string, value: any, ttl: number) => {
-    try {
-        const cacheRaw = localStorage.getItem(DASHBOARD_CACHE_KEY);
-        const cache = cacheRaw ? JSON.parse(cacheRaw) : {};
-        cache[key] = {
-            value,
-            expireAt: Date.now() + ttl,
-        };
-        localStorage.setItem(DASHBOARD_CACHE_KEY, JSON.stringify(cache));
-    } catch {}
-};
-
-const clearDashboardCache = () => {
-    localStorage.removeItem(DASHBOARD_CACHE_KEY);
-};
 
 const updateCurrentInfo = (data: Dashboard.CurrentInfo) => {
     currentInfo.value = {


### PR DESCRIPTION
#### What this PR does / why we need it?
dashboard 首屏并发请求很多重复信息，这些信息阻塞了很多模块的渲染，导致用户感受卡顿。
#### Summary of your change
通过缓存策略和分析用户心理，加快组件渲染速度。再根据需求异步刷新这些数据，用户用不到、看不见的数据直接读加载好缓存而不是再请求后端。用户重复访问 dashboard 时，所有信息不再阻塞渲染。

- 修改首次请求时的顺序，异步延迟加载优先级低的信息
- 大部分低变化的信息缓存在浏览器中，未过期或者未登出时，dashboard 直接从这里面拿，没必要重复请求后端。通过缓存策略能加快渲染速度。
- 为了避免缓存中数据不同步，按需刷新数据，用户鼠标移动到监控卡片或者应用卡片时，刷新缓存
- 添加两个手动刷新按钮让用户手动刷新数据兜底。
- 修改进入首屏时，检查自动更新的逻辑，放到最后再检查，且 24 小时内不会再调用。这个自动更新会卡很久很久，基本上dashboard 的一半时间都被他阻塞了。

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.