### PR TITLE
fix: Improve error handling in file download API

### DIFF
--- a/agent/app/api/v2/file.go
+++ b/agent/app/api/v2/file.go
@@ -521,9 +521,14 @@ func (b *BaseApi) Download(c *gin.Context) {
 	file, err := os.Open(filePath)
 	if err != nil {
 		helper.InternalServer(c, err)
+		return
 	}
 	defer file.Close()
-	info, _ := file.Stat()
+	info, err := file.Stat()
+	if err != nil {
+		helper.InternalServer(c, err)
+		return
+	}
 	c.Header("Content-Length", strconv.FormatInt(info.Size(), 10))
 	c.Header("Content-Disposition", "attachment; filename*=utf-8''"+url.PathEscape(info.Name()))
 	http.ServeContent(c.Writer, c.Request, info.Name(), info.ModTime(), file)


### PR DESCRIPTION
#### What this PR does / why we need it?
修复打开文件时，出现报错未提前return导致空指针报panic的问题。
#### Summary of your change
正确处理错误并提前 return 退出
#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.