### PR TITLE
perf: use gzipped data for improved load speed in large response

### DIFF
--- a/agent/app/api/v2/app.go
+++ b/agent/app/api/v2/app.go
@@ -1,13 +1,14 @@
 package v2
 
 import (
+	"net/http"
+	"time"
+
 	"github.com/1Panel-dev/1Panel/agent/app/api/v2/helper"
 	"github.com/1Panel-dev/1Panel/agent/app/dto"
 	"github.com/1Panel-dev/1Panel/agent/app/dto/request"
 	"github.com/1Panel-dev/1Panel/agent/i18n"
 	"github.com/gin-gonic/gin"
-	"net/http"
-	"time"
 )
 
 // @Tags App
@@ -28,7 +29,7 @@ func (b *BaseApi) SearchApp(c *gin.Context) {
 		helper.InternalServer(c, err)
 		return
 	}
-	helper.SuccessWithData(c, list)
+	helper.SuccessWithDataGzipped(c, list)
 }
 
 // @Tags App

--- a/agent/app/api/v2/dashboard.go
+++ b/agent/app/api/v2/dashboard.go
@@ -37,7 +37,7 @@ func (b *BaseApi) LoadAppLauncher(c *gin.Context) {
 		helper.InternalServer(c, err)
 		return
 	}
-	helper.SuccessWithData(c, data)
+	helper.SuccessWithDataGzipped(c, data)
 }
 
 // @Tags Dashboard

--- a/agent/app/api/v2/file.go
+++ b/agent/app/api/v2/file.go
@@ -265,7 +265,11 @@ func (b *BaseApi) GetContent(c *gin.Context) {
 		helper.InternalServer(c, err)
 		return
 	}
-	helper.SuccessWithData(c, info)
+	if info.Size > 10*1024 {
+		helper.SuccessWithDataGzipped(c, info)
+	} else {
+		helper.SuccessWithData(c, info)
+	}
 }
 
 // @Tags File

--- a/agent/app/api/v2/file.go
+++ b/agent/app/api/v2/file.go
@@ -265,7 +265,7 @@ func (b *BaseApi) GetContent(c *gin.Context) {
 		helper.InternalServer(c, err)
 		return
 	}
-	if info.Size > 10*1024 {
+	if info.Size > 2*1024 && info.Size < 5*1024*1024 {
 		helper.SuccessWithDataGzipped(c, info)
 	} else {
 		helper.SuccessWithData(c, info)

--- a/agent/app/api/v2/file.go
+++ b/agent/app/api/v2/file.go
@@ -90,7 +90,7 @@ func (b *BaseApi) GetFileTree(c *gin.Context) {
 		helper.InternalServer(c, err)
 		return
 	}
-	helper.SuccessWithData(c, tree)
+	helper.SuccessWithDataGzipped(c, tree)
 }
 
 // @Tags File

--- a/agent/app/api/v2/monitor.go
+++ b/agent/app/api/v2/monitor.go
@@ -28,7 +28,7 @@ func (b *BaseApi) LoadMonitor(c *gin.Context) {
 		helper.InternalServer(c, err)
 		return
 	}
-	helper.SuccessWithData(c, data)
+	helper.SuccessWithDataGzipped(c, data)
 }
 
 // @Tags Monitor

--- a/agent/app/api/v2/website_ssl.go
+++ b/agent/app/api/v2/website_ssl.go
@@ -1,13 +1,14 @@
 package v2
 
 import (
-	"github.com/1Panel-dev/1Panel/agent/app/model"
 	"io"
 	"mime/multipart"
 	"net/http"
 	"net/url"
 	"reflect"
 	"strconv"
+
+	"github.com/1Panel-dev/1Panel/agent/app/model"
 
 	"github.com/1Panel-dev/1Panel/agent/app/api/v2/helper"
 	"github.com/1Panel-dev/1Panel/agent/app/dto"
@@ -34,7 +35,7 @@ func (b *BaseApi) PageWebsiteSSL(c *gin.Context) {
 			helper.InternalServer(c, err)
 			return
 		}
-		helper.SuccessWithData(c, dto.PageResult{
+		helper.SuccessWithDataGzipped(c, dto.PageResult{
 			Total: total,
 			Items: accounts,
 		})
@@ -44,7 +45,7 @@ func (b *BaseApi) PageWebsiteSSL(c *gin.Context) {
 			helper.InternalServer(c, err)
 			return
 		}
-		helper.SuccessWithData(c, list)
+		helper.SuccessWithDataGzipped(c, list)
 	}
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it?
对数据较多的接口启用 gzip 以减少带宽压力。
对部分列表接口启用gzip压缩
对文件管理的文件取content的接口,在适合的大小启用gzip压缩
#### Summary of your change

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.