### PR TITLE
feat: Add path protection mechanism to prevent deletion of system dir

### DIFF
--- a/agent/app/service/recycle_bin.go
+++ b/agent/app/service/recycle_bin.go
@@ -76,6 +76,9 @@ func (r RecycleBinService) Page(search dto.PageInfo) (int64, []response.RecycleB
 }
 
 func (r RecycleBinService) Create(create request.RecycleBinCreate) error {
+	if files.IsProtected(create.SourcePath) {
+		return buserr.New("ErrPathNotDelete")
+	}
 	op := files.NewFileOp()
 	if !op.Stat(create.SourcePath) {
 		return buserr.New("ErrLinkPathNotFound")

--- a/agent/utils/files/file_op.go
+++ b/agent/utils/files/file_op.go
@@ -33,6 +33,40 @@ import (
 	"github.com/spf13/afero"
 )
 
+var protectedPaths = []string{
+	"/",
+	"/bin",
+	"/sbin",
+	"/etc",
+	"/boot",
+	"/usr",
+	"/lib",
+	"/lib64",
+	"/dev",
+	"/proc",
+	"/sys",
+	"/root",
+}
+
+func isProtected(path string) bool {
+	real, err := filepath.EvalSymlinks(path)
+	if err == nil {
+		path = real
+	}
+
+	abs, err := filepath.Abs(path)
+	if err == nil {
+		path = abs
+	}
+
+	for _, p := range protectedPaths {
+		if path == p || strings.HasPrefix(path, p+"/") {
+			return true
+		}
+	}
+	return false
+}
+
 type FileOp struct {
 	Fs afero.Fs
 }
@@ -104,6 +138,9 @@ func (f FileOp) LinkFile(source string, dst string, isSymlink bool) error {
 }
 
 func (f FileOp) DeleteDir(dst string) error {
+	if isProtected(dst) {
+		return buserr.New("ErrPathNotDelete")
+	}
 	return f.Fs.RemoveAll(dst)
 }
 
@@ -113,14 +150,23 @@ func (f FileOp) Stat(dst string) bool {
 }
 
 func (f FileOp) DeleteFile(dst string) error {
+	if isProtected(dst) {
+		return buserr.New("ErrPathNotDelete")
+	}
 	return f.Fs.Remove(dst)
 }
 
 func (f FileOp) CleanDir(dst string) error {
+	if isProtected(dst) {
+		return buserr.New("ErrPathNotDelete")
+	}
 	return cmd.RunDefaultBashCf("rm -rf %s/*", dst)
 }
 
 func (f FileOp) RmRf(dst string) error {
+	if isProtected(dst) {
+		return buserr.New("ErrPathNotDelete")
+	}
 	return cmd.RunDefaultBashCf("rm -rf %s", dst)
 }
 

--- a/agent/utils/files/file_op.go
+++ b/agent/utils/files/file_op.go
@@ -48,7 +48,7 @@ var protectedPaths = []string{
 	"/root",
 }
 
-func isProtected(path string) bool {
+func IsProtected(path string) bool {
 	real, err := filepath.EvalSymlinks(path)
 	if err == nil {
 		path = real
@@ -60,7 +60,7 @@ func isProtected(path string) bool {
 	}
 
 	for _, p := range protectedPaths {
-		if path == p || strings.HasPrefix(path, p+"/") {
+		if path == p {
 			return true
 		}
 	}
@@ -138,7 +138,7 @@ func (f FileOp) LinkFile(source string, dst string, isSymlink bool) error {
 }
 
 func (f FileOp) DeleteDir(dst string) error {
-	if isProtected(dst) {
+	if IsProtected(dst) {
 		return buserr.New("ErrPathNotDelete")
 	}
 	return f.Fs.RemoveAll(dst)
@@ -150,21 +150,21 @@ func (f FileOp) Stat(dst string) bool {
 }
 
 func (f FileOp) DeleteFile(dst string) error {
-	if isProtected(dst) {
+	if IsProtected(dst) {
 		return buserr.New("ErrPathNotDelete")
 	}
 	return f.Fs.Remove(dst)
 }
 
 func (f FileOp) CleanDir(dst string) error {
-	if isProtected(dst) {
+	if IsProtected(dst) {
 		return buserr.New("ErrPathNotDelete")
 	}
 	return cmd.RunDefaultBashCf("rm -rf %s/*", dst)
 }
 
 func (f FileOp) RmRf(dst string) error {
-	if isProtected(dst) {
+	if IsProtected(dst) {
 		return buserr.New("ErrPathNotDelete")
 	}
 	return cmd.RunDefaultBashCf("rm -rf %s", dst)


### PR DESCRIPTION
#### What this PR does / why we need it?
由于1panel是root运行，而且没有保护机制，1panel的文件管理是可以直接删掉系统重要文件夹，手动rm -rf / 删库跑路的
etc dev 什么的直接都可以遍历删除，删除即炸机无法恢复。虽然大部分用户不会犯傻但是总得做点保护。

特地开了个虚拟机进行炸机测试，下图是直接用文件管理删 /etc 后的效果，其他大部分重要目录删完直接ssh或者命令都炸了，想截图都做不到
<img width="790" height="116" alt="image" src="https://github.com/user-attachments/assets/bc690402-d16d-40c1-a874-c688108a97e6" />

#### Summary of your change
添加保护机制，不允许对指定路径进行操作。
<img width="827" height="441" alt="image" src="https://github.com/user-attachments/assets/a26f94de-89e3-4552-9e93-60a111b8523b" />


#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.