### PR TITLE
feat: Implement ETag support for app icon caching in GetAppIcon API

### DIFF
--- a/agent/app/api/v2/app.go
+++ b/agent/app/api/v2/app.go
@@ -1,8 +1,10 @@
 package v2
 
 import (
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/1Panel-dev/1Panel/agent/app/api/v2/helper"
 	"github.com/1Panel-dev/1Panel/agent/app/dto"
@@ -210,13 +212,24 @@ func (b *BaseApi) GetAppIcon(c *gin.Context) {
 		helper.BadRequest(c, err)
 		return
 	}
+
 	iconBytes, err := appService.GetAppIcon(appID)
 	if err != nil {
 		helper.InternalServer(c, err)
 		return
 	}
+
+	sum := md5.Sum(iconBytes)
+	etagStr := hex.EncodeToString(sum[:])
+	etagHeader := fmt.Sprintf(`"%s"`, etagStr)
+
+	if c.GetHeader("If-None-Match") == etagHeader {
+		c.Status(http.StatusNotModified)
+		return
+	}
+
+	c.Header("ETag", etagHeader)
 	c.Header("Content-Type", "image/png")
-	c.Header("Cache-Control", "public, max-age=31536000, immutable")
-	c.Header("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+	c.Header("Cache-Control", "public, max-age=86400, must-revalidate")
 	c.Data(http.StatusOK, "image/png", iconBytes)
 }


### PR DESCRIPTION
#### What this PR does / why we need it?
Cache-Control 设置会让图片用缓存不变不更改策略
而Last-Modified设置的值又会在下次请求重新拉取
导致这两个字段冲突,只做到了看似有用的缓存效果。
复现方法：
1. 进入应用商店，访问第一页，然后切换到第二页。
2. 切换其他卡片，等待若干分钟
3. 再切回应用商店，第一页的图标仍然会请求而不是读缓存
#### Summary of your change
换成 etag 方案
一天内在缓存内读取，并保存 etag,一天过期后，请求后端会比对 etag,如果图片没变直接返回 304状态码，不返回内容让浏览器用缓存内容，减少网络传输的时间，同时保证版本更新。
效果:
接口返回的头：
<img width="710" height="162" alt="image" src="https://github.com/user-attachments/assets/e0f21121-9b91-4205-af72-0f78e6c25d0d" />

过期后请求 ：
<img width="718" height="428" alt="image" src="https://github.com/user-attachments/assets/2d4ae5ba-3845-45da-a91d-240e89cf4479" />

后端响应速度：
<img width="806" height="217" alt="image" src="https://github.com/user-attachments/assets/d11c3402-39ae-4405-95d3-22c60c1a5960" />

86400 一天缓存的值可以视情况改动，一般来说app 的 icon 很难变

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.