### PR TITLE
fix: Enhance error handling in file saving process

### DIFF
--- a/frontend/src/views/host/file-management/code-editor/index.vue
+++ b/frontend/src/views/host/file-management/code-editor/index.vue
@@ -876,10 +876,9 @@ const saveContent = async () => {
                 isEdit.value = false;
                 oldFileContent.value = form.value.content;
                 MsgSuccess(i18n.global.t('commons.msg.updateSuccess'));
-            }else{
+            } else {
                 MsgError(i18n.global.t('common.status.failed'));
                 isEdit.value = false;
-                
             }
         } finally {
             loading.value = false;

--- a/frontend/src/views/host/file-management/code-editor/index.vue
+++ b/frontend/src/views/host/file-management/code-editor/index.vue
@@ -877,7 +877,7 @@ const saveContent = async () => {
                 oldFileContent.value = form.value.content;
                 MsgSuccess(i18n.global.t('commons.msg.updateSuccess'));
             } else {
-                MsgError(i18n.global.t('common.status.failed'));
+                MsgError(i18n.global.t('commons.status.failed'));
                 isEdit.value = false;
             }
         } finally {

--- a/frontend/src/views/host/file-management/code-editor/index.vue
+++ b/frontend/src/views/host/file-management/code-editor/index.vue
@@ -393,7 +393,7 @@
 <script lang="ts" setup>
 import { createFile, getFileContent, getFilesTree, saveFileContent } from '@/api/modules/files';
 import i18n from '@/lang';
-import { MsgSuccess, MsgWarning } from '@/utils/message';
+import { MsgError, MsgSuccess, MsgWarning } from '@/utils/message';
 import * as monaco from 'monaco-editor';
 import { computed, nextTick, onBeforeUnmount, onMounted, reactive, ref } from 'vue';
 import { Languages } from '@/global/mimetype';
@@ -867,19 +867,23 @@ const quickSave = () => {
     saveContent();
 };
 
-const saveContent = () => {
+const saveContent = async () => {
     if (isEdit.value) {
         loading.value = true;
-        saveFileContent(form.value)
-            .then(() => {
-                loading.value = false;
+        try {
+            const res = await saveFileContent(form.value);
+            if (res) {
                 isEdit.value = false;
                 oldFileContent.value = form.value.content;
                 MsgSuccess(i18n.global.t('commons.msg.updateSuccess'));
-            })
-            .catch(() => {
-                loading.value = false;
-            });
+            }else{
+                MsgError(i18n.global.t('common.status.failed'));
+                isEdit.value = false;
+                
+            }
+        } finally {
+            loading.value = false;
+        }
     } else {
         MsgWarning(i18n.global.t('file.noEdit'));
     }


### PR DESCRIPTION
#### What this PR does / why we need it?
修复错误状态下，返回仍然更新成功的问题
<img width="1221" height="672" alt="image" src="https://github.com/user-attachments/assets/a2e553ae-b60e-448a-af8c-f3141cb1f95e" />
#### Summary of your change
保存错误显示错误信息，而不是保存成功

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.