### PR TITLE
feat: Add support for AWS Route 53 DNS provider

### DIFF
--- a/agent/go.mod
+++ b/agent/go.mod
@@ -86,6 +86,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.14 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.14 // indirect
+	github.com/aws/aws-sdk-go-v2/service/route53 v1.61.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.10 // indirect

--- a/agent/go.sum
+++ b/agent/go.sum
@@ -157,6 +157,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.14 h1:FIouAnCE
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.14/go.mod h1:UTwDc5COa5+guonQU8qBikJo1ZJ4ln2r1MkF7Dqag1E=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.14 h1:FzQE21lNtUor0Fb7QNgnEyiRCBlolLTX/Z1j65S7teM=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.14/go.mod h1:s1ydyWG9pm3ZwmmYN21HKyG9WzAZhYVW85wMHs5FV6w=
+github.com/aws/aws-sdk-go-v2/service/route53 v1.61.0 h1:W3+0Cbc9awFBr9Yt7nFUkvB4N4e7vVIGtKD1qDttXn4=
+github.com/aws/aws-sdk-go-v2/service/route53 v1.61.0/go.mod h1:Wa3q5R2uwIfIL3HZH+vG1/P9y7CjjfzTgcz5IWXlsZs=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.92.1 h1:OgQy/+0+Kc3khtqiEOk23xQAglXi3Tj0y5doOxbi5tg=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.92.1/go.mod h1:wYNqY3L02Z3IgRYxOBPH9I1zD9Cjh9hI5QOy/eOjQvw=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.2 h1:MxMBdKTYBjPQChlJhi4qlEueqB1p1KcbTEa7tD5aqPs=

--- a/agent/utils/ssl/dns_provider.go
+++ b/agent/utils/ssl/dns_provider.go
@@ -21,6 +21,7 @@ import (
 	"github.com/go-acme/lego/v4/providers/dns/ovh"
 	"github.com/go-acme/lego/v4/providers/dns/rainyun"
 	"github.com/go-acme/lego/v4/providers/dns/regru"
+	"github.com/go-acme/lego/v4/providers/dns/route53"
 	"github.com/go-acme/lego/v4/providers/dns/spaceship"
 	"github.com/go-acme/lego/v4/providers/dns/tencentcloud"
 	"github.com/go-acme/lego/v4/providers/dns/vercel"
@@ -35,6 +36,7 @@ const (
 	DnsPod       DnsType = "DnsPod"
 	AliYun       DnsType = "AliYun"
 	AliESA       DnsType = "AliESA"
+	AWSRoute53   DnsType = "AWSRoute53"
 	CloudFlare   DnsType = "CloudFlare"
 	CloudDns     DnsType = "CloudDns"
 	NameSilo     DnsType = "NameSilo"
@@ -120,6 +122,19 @@ func getDNSProviderConfig(dnsType DnsType, params string) (challenge.Provider, e
 		config.PollingInterval = pollingInterval
 		config.TTL = ttl
 		p, err = aliesa.NewDNSProviderConfig(config)
+	case AWSRoute53:
+		config := route53.NewDefaultConfig()
+		config.AccessKeyID = param.AccessKey
+		config.SecretAccessKey = param.SecretKey
+		config.Region = param.Region
+		if config.Region == "" {
+			config.Region = "us-east-1"
+		}
+		config.HostedZoneID = param.Endpoint
+		config.PropagationTimeout = propagationTimeout
+		config.PollingInterval = pollingInterval
+		config.TTL = ttl
+		p, err = route53.NewDNSProviderConfig(config)
 	case CloudFlare:
 		config := cloudflare.NewDefaultConfig()
 		config.AuthEmail = param.Email

--- a/frontend/src/global/mimetype.ts
+++ b/frontend/src/global/mimetype.ts
@@ -181,6 +181,10 @@ export const DNSTypes = [
         value: 'AliESA',
     },
     {
+        label: i18n.global.t('website.awsRoute53'),
+        value: 'AWSRoute53',
+    },
+    {
         label: i18n.global.t('website.tencentCloud'),
         value: 'TencentCloud',
     },

--- a/frontend/src/lang/modules/en.ts
+++ b/frontend/src/lang/modules/en.ts
@@ -2351,6 +2351,7 @@ const message = {
         createDnsAccount: 'DNS account',
         aliyun: 'Aliyun DNS',
         aliEsa: 'Aliyun ESA',
+        awsRoute53: 'AWS Route 53',
         manual: 'Manual parsing',
         key: 'Key',
         check: 'View',
@@ -2831,6 +2832,7 @@ const message = {
         pushNode: 'Sync to Other Nodes',
         pushNodeHelper: 'Push to selected nodes after application/renewal',
         fromMaster: 'Master Node Push',
+        hostedZoneID: 'Hosted Zone ID',
     },
     firewall: {
         create: 'Create rule',

--- a/frontend/src/lang/modules/es-es.ts
+++ b/frontend/src/lang/modules/es-es.ts
@@ -2350,6 +2350,7 @@ const message = {
         createDnsAccount: 'Cuenta DNS',
         aliyun: 'Aliyun DNS',
         aliEsa: 'Aliyun ESA',
+        awsRoute53: 'AWS Route 53',
         manual: 'Resolución manual',
         key: 'Clave',
         check: 'Ver',
@@ -2808,6 +2809,7 @@ const message = {
         pushNode: 'Sincronizar con otros nodos',
         pushNodeHelper: 'Enviar a los nodos seleccionados después de la aplicación/renovación',
         fromMaster: 'Envío desde el nodo maestro',
+        hostedZoneID: 'Hosted Zone ID',
     },
     firewall: {
         create: 'Crear regla',

--- a/frontend/src/lang/modules/ja.ts
+++ b/frontend/src/lang/modules/ja.ts
@@ -2271,6 +2271,7 @@ const message = {
         createDnsAccount: 'DNSアカウント',
         aliyun: 'エイリアン',
         aliEsa: 'エイリアン ESA',
+        awsRoute53: 'AWS Route 53',
         manual: '手動解析',
         key: '鍵',
         check: 'ビュー',
@@ -2750,6 +2751,7 @@ const message = {
         pushNode: '他のノードに同期',
         pushNodeHelper: '申請/更新後に選択したノードにプッシュ',
         fromMaster: 'マスターノードからのプッシュ',
+        hostedZoneID: 'Hosted Zone ID',
     },
     firewall: {
         create: 'ルールを作成します',

--- a/frontend/src/lang/modules/ko.ts
+++ b/frontend/src/lang/modules/ko.ts
@@ -2231,6 +2231,7 @@ const message = {
         createDnsAccount: 'DNS 계정 생성',
         aliyun: '알리윤',
         aliEsa: '알리윤 ESA',
+        awsRoute53: 'AWS Route 53',
         manual: '수동 설정',
         key: '키',
         check: '보기',
@@ -2701,6 +2702,7 @@ const message = {
         pushNode: '다른 노드에 동기화',
         pushNodeHelper: '신청/갱신 후 선택한 노드로 푸시',
         fromMaster: '마스터 노드에서 푸시',
+        hostedZoneID: 'Hosted Zone ID',
     },
     firewall: {
         create: '규칙 만들기',

--- a/frontend/src/lang/modules/ms.ts
+++ b/frontend/src/lang/modules/ms.ts
@@ -2325,6 +2325,7 @@ const message = {
         createDnsAccount: 'Akaun DNS',
         aliyun: 'Aliyun',
         aliEsa: 'Aliyun ESA',
+        awsRoute53: 'AWS Route 53',
         manual: 'Penyelesaian Manual',
         key: 'Kunci',
         check: 'Lihat',
@@ -2810,6 +2811,7 @@ const message = {
         pushNode: 'Segerakan ke Nod Lain',
         pushNodeHelper: 'Tolak ke nod terpilih selepas permohonan/pembaharuan',
         fromMaster: 'Tolak dari Nod Utama',
+        hostedZoneID: 'Hosted Zone ID',
     },
     firewall: {
         create: 'Buat peraturan',

--- a/frontend/src/lang/modules/pt-br.ts
+++ b/frontend/src/lang/modules/pt-br.ts
@@ -2327,6 +2327,7 @@ const message = {
         createDnsAccount: 'Conta DNS',
         aliyun: 'Aliyun',
         aliEsa: 'Aliyun ESA',
+        awsRoute53: 'AWS Route 53',
         manual: 'Análise manual',
         key: 'Chave',
         check: 'Ver',
@@ -2816,6 +2817,7 @@ const message = {
         pushNode: 'Sincronizar com Outros Nós',
         pushNodeHelper: 'Enviar para os nós selecionados após a aplicação/renovação',
         fromMaster: 'Envio do Nó Mestre',
+        hostedZoneID: 'Hosted Zone ID',
     },
     firewall: {
         create: 'Criar regra',

--- a/frontend/src/lang/modules/ru.ts
+++ b/frontend/src/lang/modules/ru.ts
@@ -2322,6 +2322,7 @@ const message = {
         createDnsAccount: 'DNS аккаунт',
         aliyun: 'Aliyun',
         aliEsa: 'Aliyun ESA',
+        awsRoute53: 'AWS Route 53',
         manual: 'Ручная настройка',
         key: 'Ключ',
         check: 'Просмотр',
@@ -2810,6 +2811,7 @@ const message = {
         pushNode: 'Синхронизация с другими узлами',
         pushNodeHelper: 'Отправить на выбранные узлы после заявки/продления',
         fromMaster: 'Отправка с главного узла',
+        hostedZoneID: 'Hosted Zone ID',
     },
     firewall: {
         create: 'Создать правило',

--- a/frontend/src/lang/modules/tr.ts
+++ b/frontend/src/lang/modules/tr.ts
@@ -2382,6 +2382,7 @@ const message = {
         createDnsAccount: 'DNS hesabı',
         aliyun: 'Aliyun DNS',
         aliEsa: 'Aliyun ESA',
+        awsRoute53: 'AWS Route 53',
         manual: 'Manuel çözümleme',
         key: 'Anahtar',
         check: 'Görüntüle',
@@ -2869,6 +2870,7 @@ const message = {
         pushNode: 'Diğer Düğümlere Senkronize Et',
         pushNodeHelper: 'Başvuru/yenilemeden sonra seçilen düğümlere gönder',
         fromMaster: 'Ana Düğümden Gönder',
+        hostedZoneID: 'Hosted Zone ID',
     },
     firewall: {
         create: 'Kural oluştur',

--- a/frontend/src/lang/modules/zh-Hant.ts
+++ b/frontend/src/lang/modules/zh-Hant.ts
@@ -2184,6 +2184,7 @@ const message = {
         createDnsAccount: 'DNS 帳戶',
         aliyun: '阿里雲 DNS',
         aliEsa: '阿里雲 ESA',
+        awsRoute53: 'AWS Route 53（亞馬遜）',
         manual: '手動解析',
         key: '金鑰',
         check: '查看',
@@ -2632,6 +2633,7 @@ const message = {
         pushNode: '同步到其他節點',
         pushNodeHelper: '申請/續期之後推送到選擇的節點',
         fromMaster: '主節點推送',
+        hostedZoneID: '託管區域 ID',
     },
     firewall: {
         create: '建立規則',

--- a/frontend/src/lang/modules/zh.ts
+++ b/frontend/src/lang/modules/zh.ts
@@ -2180,6 +2180,7 @@ const message = {
         createDnsAccount: 'DNS 账户',
         aliyun: '阿里云',
         aliEsa: '阿里云 ESA',
+        awsRoute53: 'AWS Route 53（亚马逊）',
         manual: '手动解析',
         key: '密钥',
         check: '查看',
@@ -2628,6 +2629,7 @@ const message = {
         pushNode: '同步到其他节点',
         pushNodeHelper: '申请/续期之后推送到选择的节点',
         fromMaster: '主节点推送',
+        hostedZoneID: '托管区域 ID',
     },
     firewall: {
         create: '创建规则',

--- a/frontend/src/views/website/ssl/dns-account/create/index.vue
+++ b/frontend/src/views/website/ssl/dns-account/create/index.vue
@@ -24,7 +24,8 @@
                             account.type === 'AliYun' ||
                             account.type === 'AliESA' ||
                             account.type === 'HuaweiCloud' ||
-                            account.type === 'BaiduCloud'
+                            account.type === 'BaiduCloud' ||
+                            account.type === 'AWSRoute53'
                         "
                     >
                         <el-form-item label="Access key" prop="authorization.accessKey">
@@ -157,6 +158,21 @@
                         </el-form-item>
                         <el-form-item label="BASE URL" prop="authorization.baseURL" :rules="[Rules.requiredInput]">
                             <el-input v-model.trim="account.authorization['baseURL']"></el-input>
+                        </el-form-item>
+                    </div>
+                    <div v-if="account.type === 'AWSRoute53'">
+                        <el-form-item label="Region" prop="authorization.region">
+                            <el-input
+                                v-model.trim="account.authorization['region']"
+                                :placeholder="'us-east-1'"
+                            ></el-input>
+                        </el-form-item>
+                        <el-form-item
+                            :label="$t('ssl.hostedZoneID')"
+                            prop="authorization.endpoint"
+                            :rules="[Rules.requiredInput]"
+                        >
+                            <el-input v-model.trim="account.authorization['endpoint']"></el-input>
                         </el-form-item>
                     </div>
                 </el-form>


### PR DESCRIPTION
#### What this PR does / why we need it?
Add support for AWS Route 53 as a DNS provider, enabling automatic DNS-01 validation via ACME.
Close #10562

#### Summary of your change
- Added `AWSRoute53` DNS type in backend and integrated lego’s Route53 provider.
- Updated go.mod/go.sum with AWS SDK dependencies.
- Updated frontend UI and i18n to support the new DNS provider option.

  **Testing**
  Route 53 DNS-01 flow has been fully validated:
  ````
  2025/12/02 17:36:03 开始申请证书，域名 [demo.gotocam.app] 申请方式 [DNS 自动] DNS 账号 [aws] 厂商 [AWSRoute53]
  2025/12/02 17:36:03 [INFO] [demo.gotocam.app] acme: Obtaining bundled SAN certificate
  2025/12/02 17:36:04 [INFO] [demo.gotocam.app] AuthURL: https://acme-v02.api.letsencrypt.org/acme/authz/xxxx/xxxx
  2025/12/02 17:36:04 [INFO] [demo.gotocam.app] acme: Could not find solver for: tls-alpn-01
  2025/12/02 17:36:04 [INFO] [demo.gotocam.app] acme: Could not find solver for: http-01
  2025/12/02 17:36:04 [INFO] [demo.gotocam.app] acme: use dns-01 solver
  2025/12/02 17:36:04 [INFO] [demo.gotocam.app] acme: Preparing to solve DNS-01
  2025/12/02 17:36:30 [INFO] [demo.gotocam.app] acme: Trying to solve DNS-01
  2025/12/02 17:36:30 [INFO] [demo.gotocam.app] acme: Checking DNS record propagation. [nameservers=10.255.255.254:53]
  2025/12/02 17:36:40 [INFO] Wait for propagation [timeout: 30m0s, interval: 10s]
  2025/12/02 17:36:51 [INFO] [demo.gotocam.app] The server validated our request
  2025/12/02 17:36:51 [INFO] [demo.gotocam.app] acme: Cleaning DNS-01 challenge
  2025/12/02 17:37:15 [INFO] [demo.gotocam.app] acme: Validations succeeded; requesting certificates
  2025/12/02 17:37:16 [INFO] [demo.gotocam.app] Server responded with a certificate.
  2025/12/02 17:37:16 申请 [demo.gotocam.app] 证书成功！！
  ````
  <img width="2050" height="932" alt="image" src="https://github.com/user-attachments/assets/03c9dd37-844f-42c5-bbc1-ddec4933e5d7" />

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.