### PR TITLE
fix: Ensure proper client closure in volume and device clean operations

### DIFF
--- a/agent/app/service/container_volume.go
+++ b/agent/app/service/container_volume.go
@@ -19,6 +19,7 @@ func (u *ContainerService) PageVolume(req dto.SearchWithPage) (int64, interface{
 	if err != nil {
 		return 0, nil, err
 	}
+	defer client.Close()
 	list, err := client.VolumeList(context.TODO(), volume.ListOptions{})
 	if err != nil {
 		return 0, nil, err

--- a/agent/app/service/device_clean.go
+++ b/agent/app/service/device_clean.go
@@ -413,6 +413,7 @@ func loadContainerTree() []dto.CleanTree {
 	if err != nil {
 		return treeData
 	}
+	defer client.Close()
 	diskUsage, err := client.DiskUsage(context.Background(), types.DiskUsageOptions{})
 	if err != nil {
 		return treeData
@@ -552,6 +553,7 @@ func dropBuildCache() (int, int) {
 		global.LOG.Errorf("do not get docker client")
 		return 0, 0
 	}
+	defer client.Close()
 	opts := build.CachePruneOptions{}
 	opts.All = true
 	res, err := client.BuildCachePrune(context.Background(), opts)
@@ -568,6 +570,7 @@ func dropImages() (int, int) {
 		global.LOG.Errorf("do not get docker client")
 		return 0, 0
 	}
+	defer client.Close()
 	pruneFilters := filters.NewArgs()
 	pruneFilters.Add("dangling", "false")
 	res, err := client.ImagesPrune(context.Background(), pruneFilters)
@@ -584,6 +587,7 @@ func dropContainers() (int, int) {
 		global.LOG.Errorf("do not get docker client")
 		return 0, 0
 	}
+	defer client.Close()
 	pruneFilters := filters.NewArgs()
 	res, err := client.ContainersPrune(context.Background(), pruneFilters)
 	if err != nil {
@@ -599,6 +603,7 @@ func dropVolumes() (int, int) {
 		global.LOG.Errorf("do not get docker client")
 		return 0, 0
 	}
+	defer client.Close()
 	pruneFilters := filters.NewArgs()
 	versions, err := client.ServerVersion(context.Background())
 	if err != nil {


### PR DESCRIPTION
#### What this PR does / why we need it?
很有几处docker操作在NewClient打开新链接后没有close逻辑，导致transport不回收，虽然影响不大但是还是加上了
#### Summary of your change

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.