### PR TITLE
perf: remove useless stat checking logic

### DIFF
--- a/core/init/proxy/proxy.go
+++ b/core/init/proxy/proxy.go
@@ -15,8 +15,11 @@ var (
 )
 
 func Init() {
+	dialer := &net.Dialer{
+		Timeout: 5 * time.Second,
+	}
 	dialUnix := func(ctx context.Context, network, addr string) (net.Conn, error) {
-		return net.Dial("unix", sockPath)
+		return dialer.DialContext(ctx, "unix", sockPath)
 	}
 	transport := &http.Transport{
 		DialContext:         dialUnix,
@@ -33,7 +36,7 @@ func Init() {
 		Transport: transport,
 		ErrorHandler: func(rw http.ResponseWriter, req *http.Request, err error) {
 			rw.WriteHeader(http.StatusBadGateway)
-			rw.Write([]byte("Bad Gateway"))
+			_, _ = rw.Write([]byte("Bad Gateway: " + err.Error()))
 		},
 	}
 }

--- a/core/init/proxy/proxy.go
+++ b/core/init/proxy/proxy.go
@@ -8,9 +8,9 @@ import (
 	"time"
 )
 
-var (
-	sockPath = "/etc/1panel/agent.sock"
+const SockPath = "/etc/1panel/agent.sock"
 
+var (
 	LocalAgentProxy *httputil.ReverseProxy
 )
 
@@ -19,7 +19,7 @@ func Init() {
 		Timeout: 5 * time.Second,
 	}
 	dialUnix := func(ctx context.Context, network, addr string) (net.Conn, error) {
-		return dialer.DialContext(ctx, "unix", sockPath)
+		return dialer.DialContext(ctx, "unix", SockPath)
 	}
 	transport := &http.Transport{
 		DialContext:         dialUnix,

--- a/core/init/router/proxy.go
+++ b/core/init/router/proxy.go
@@ -3,7 +3,6 @@ package router
 import (
 	"net/http"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 
@@ -52,11 +51,6 @@ func Proxy() gin.HandlerFunc {
 		}
 
 		if !strings.HasPrefix(c.Request.URL.Path, "/api/v2/core") && (currentNode == "local" || len(currentNode) == 0) {
-			sockPath := "/etc/1panel/agent.sock"
-			if _, err := os.Stat(sockPath); err != nil {
-				helper.ErrorWithDetail(c, http.StatusBadRequest, "ErrProxy", err)
-				return
-			}
 			defer func() {
 				if err := recover(); err != nil && err != http.ErrAbortHandler {
 					global.LOG.Debug(err)


### PR DESCRIPTION
#### What this PR does / why we need it?
每一个请求都stat一遍有点太浪费了，而且没有必要。
#### Summary of your change
移除os.stat，换成超时 dial 逻辑，超时即报 502 错误。测试 agent 挂掉时这个新逻辑不影响 core，agent再启动也没有影响
#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.