### PR TITLE
perf: Improve SSH session retrieval performance

### DIFF
--- a/agent/utils/websocket/process_data.go
+++ b/agent/utils/websocket/process_data.go
@@ -3,11 +3,12 @@ package websocket
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/1Panel-dev/1Panel/agent/utils/common"
 	"sort"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/1Panel-dev/1Panel/agent/utils/common"
 
 	"github.com/1Panel-dev/1Panel/agent/global"
 	"github.com/1Panel-dev/1Panel/agent/utils/files"
@@ -252,46 +253,67 @@ func getSSHSessions(config SSHSessionConfig) (res []byte, err error) {
 		users     []host.UserStat
 		processes []*process.Process
 	)
-	processes, err = process.Processes()
-	if err != nil {
-		return
-	}
 	users, err = host.Users()
 	if err != nil {
 		res, err = json.Marshal(result)
 		return
 	}
+
+	usersByHost := make(map[string][]host.UserStat)
+	for _, user := range users {
+		if user.Host == "" {
+			continue
+		}
+		if config.LoginUser != "" && !strings.Contains(user.User, config.LoginUser) {
+			continue
+		}
+		if config.LoginIP != "" && !strings.Contains(user.Host, config.LoginIP) {
+			continue
+		}
+		usersByHost[user.Host] = append(usersByHost[user.Host], user)
+	}
+
+	if len(usersByHost) == 0 {
+		res, err = json.Marshal(result)
+		return
+	}
+
+	processes, err = process.Processes()
+	if err != nil {
+		return
+	}
+
 	for _, proc := range processes {
 		name, _ := proc.Name()
 		if name != "sshd" || proc.Pid == 0 {
 			continue
 		}
 		connections, _ := proc.Connections()
+		if len(connections) == 0 {
+			continue
+		}
+
+		cmdline, cmdErr := proc.Cmdline()
+		if cmdErr != nil {
+			continue
+		}
+
 		for _, conn := range connections {
-			for _, user := range users {
-				if user.Host == "" {
-					continue
-				}
-				if conn.Raddr.IP == user.Host {
-					if config.LoginUser != "" && !strings.Contains(user.User, config.LoginUser) {
-						continue
-					}
-					if config.LoginIP != "" && !strings.Contains(user.Host, config.LoginIP) {
-						continue
-					}
-					if terminal, err := proc.Cmdline(); err == nil {
-						if strings.Contains(terminal, user.Terminal) {
-							session := sshSession{
-								Username: user.User,
-								Host:     user.Host,
-								Terminal: user.Terminal,
-								PID:      proc.Pid,
-							}
-							t := time.Unix(int64(user.Started), 0)
-							session.LoginTime = t.Format("2006-1-2 15:04:05")
-							result = append(result, session)
-						}
-					}
+			matchedUsers, exists := usersByHost[conn.Raddr.IP]
+			if !exists {
+				continue
+			}
+
+			for _, user := range matchedUsers {
+				if strings.Contains(cmdline, user.Terminal) {
+					t := time.Unix(int64(user.Started), 0)
+					result = append(result, sshSession{
+						Username:  user.User,
+						Host:      user.Host,
+						Terminal:  user.Terminal,
+						PID:       proc.Pid,
+						LoginTime: t.Format("2006-1-2 15:04:05"),
+					})
 				}
 			}
 		}


### PR DESCRIPTION
#### What this PR does / why we need it?
优化获取ssh session逻辑的执行顺序和检测方案，减少不必要开销
#### Summary of your change
- 先去过滤出符合条件的用户信息，确认有需要找 pid的用户再执行process.Processes()这个有开销的函数, 而不是先去查 process
- 把 proc.cmdLine 移出循环，只需要执行一次拿到值就够了
- 用 map 预存 host，直接通过 map[connect 的 IP] 来看是否命中


测试返回数据均不变
<img width="1080" height="687" alt="image" src="https://github.com/user-attachments/assets/532a4837-36ff-4556-be12-2499be59ac00" />

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.