### PR TITLE
feat: add support for Porkbun DNS provider

### DIFF
--- a/backend/utils/ssl/client.go
+++ b/backend/utils/ssl/client.go
@@ -3,13 +3,9 @@ package ssl
 import (
 	"crypto"
 	"encoding/json"
-	"github.com/go-acme/lego/v4/providers/dns/westcn"
 	"os"
 	"strings"
 	"time"
-
-	"github.com/go-acme/lego/v4/providers/dns/freemyip"
-	"github.com/go-acme/lego/v4/providers/dns/rainyun"
 
 	"github.com/1Panel-dev/1Panel/backend/app/model"
 	"github.com/go-acme/lego/v4/acme"
@@ -23,13 +19,17 @@ import (
 	"github.com/go-acme/lego/v4/providers/dns/cloudflare"
 	"github.com/go-acme/lego/v4/providers/dns/cloudns"
 	"github.com/go-acme/lego/v4/providers/dns/dnspod"
+	"github.com/go-acme/lego/v4/providers/dns/freemyip"
 	"github.com/go-acme/lego/v4/providers/dns/godaddy"
 	"github.com/go-acme/lego/v4/providers/dns/huaweicloud"
 	"github.com/go-acme/lego/v4/providers/dns/namecheap"
 	"github.com/go-acme/lego/v4/providers/dns/namedotcom"
 	"github.com/go-acme/lego/v4/providers/dns/namesilo"
+	"github.com/go-acme/lego/v4/providers/dns/porkbun"
+	"github.com/go-acme/lego/v4/providers/dns/rainyun"
 	"github.com/go-acme/lego/v4/providers/dns/tencentcloud"
 	"github.com/go-acme/lego/v4/providers/dns/volcengine"
+	"github.com/go-acme/lego/v4/providers/dns/westcn"
 	"github.com/go-acme/lego/v4/providers/http/webroot"
 	"github.com/go-acme/lego/v4/registration"
 	"github.com/pkg/errors"
@@ -87,6 +87,7 @@ const (
 	HuaweiCloud  DnsType = "HuaweiCloud"
 	RainYun      DnsType = "RainYun"
 	WestCN       DnsType = "WestCN"
+	PorkBun      DnsType = "PorkBun"
 )
 
 type DNSParam struct {
@@ -244,6 +245,14 @@ func (c *AcmeClient) UseDns(dnsType DnsType, params string, websiteSSL model.Web
 		westcnConfig.PollingInterval = pollingInterval
 		westcnConfig.TTL = ttl
 		p, err = westcn.NewDNSProviderConfig(westcnConfig)
+	case PorkBun:
+		porkbunConfig := porkbun.NewDefaultConfig()
+		porkbunConfig.APIKey = param.APIkey
+		porkbunConfig.SecretAPIKey = param.SecretKey
+		porkbunConfig.PropagationTimeout = propagationTimeout
+		porkbunConfig.PollingInterval = pollingInterval
+		porkbunConfig.TTL = ttl
+		p, err = porkbun.NewDNSProviderConfig(porkbunConfig)
 	}
 	if err != nil {
 		return err

--- a/frontend/src/global/mimetype.ts
+++ b/frontend/src/global/mimetype.ts
@@ -213,6 +213,10 @@ export const DNSTypes = [
         value: 'WestCN',
     },
     {
+        label: 'PorkBun',
+        value: 'PorkBun',
+    },
+    {
         label: i18n.global.t('website.volcengine'),
         value: 'Volcengine',
     },

--- a/frontend/src/views/website/ssl/dns-account/create/index.vue
+++ b/frontend/src/views/website/ssl/dns-account/create/index.vue
@@ -142,8 +142,8 @@
                         <el-form-item label="API Key" prop="authorization.apiKey">
                             <el-input v-model.trim="account.authorization['apiKey']"></el-input>
                         </el-form-item>
-                        <el-form-item label="Secret Key" prop="authorization.SecretKey">
-                            <el-input v-model.trim="account.authorization['SecretKey']"></el-input>
+                        <el-form-item label="Secret Key" prop="authorization.secretKey">
+                            <el-input v-model.trim="account.authorization['secretKey']"></el-input>
                         </el-form-item>
                     </div>
                 </el-form>

--- a/frontend/src/views/website/ssl/dns-account/create/index.vue
+++ b/frontend/src/views/website/ssl/dns-account/create/index.vue
@@ -138,6 +138,14 @@
                             <el-input v-model.trim="account.authorization['password']"></el-input>
                         </el-form-item>
                     </div>
+                    <div v-if="account.type === 'PorkBun'">
+                        <el-form-item label="API Key" prop="authorization.apiKey">
+                            <el-input v-model.trim="account.authorization['apiKey']"></el-input>
+                        </el-form-item>
+                        <el-form-item label="Secret Key" prop="authorization.SecretKey">
+                            <el-input v-model.trim="account.authorization['SecretKey']"></el-input>
+                        </el-form-item>
+                    </div>
                 </el-form>
             </el-col>
         </el-row>

--- a/go.mod
+++ b/go.mod
@@ -52,8 +52,6 @@ require (
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.0
 	github.com/swaggo/swag v1.16.3
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudapp v1.0.1115
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.1115
 	github.com/tencentyun/cos-go-sdk-v5 v0.7.46
 	github.com/xlzd/gotp v0.1.0
 	go4.org v0.0.0-20230225012048-214862532bf5
@@ -64,7 +62,6 @@ require (
 	golang.org/x/sys v0.30.0
 	golang.org/x/term v0.29.0
 	golang.org/x/text v0.22.0
-	google.golang.org/genproto v0.0.0-20241021214115-324edc3d5d38
 	gopkg.in/ini.v1 v1.67.0
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/gorm v1.25.7
@@ -203,6 +200,7 @@ require (
 	github.com/nrdcg/freemyip v0.3.0 // indirect
 	github.com/nrdcg/mailinabox v0.2.0 // indirect
 	github.com/nrdcg/namesilo v0.2.1 // indirect
+	github.com/nrdcg/porkbun v0.4.0 // indirect
 	github.com/nwaples/rardecode/v2 v2.0.0-beta.2 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b // indirect
@@ -226,6 +224,7 @@ require (
 	github.com/spf13/cast v1.6.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.10.0 // indirect
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.1115 // indirect
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dnspod v1.0.1065 // indirect
 	github.com/therootcompany/xz v1.0.1 // indirect
 	github.com/theupdateframework/notary v0.7.0 // indirect
@@ -263,6 +262,7 @@ require (
 	golang.org/x/mod v0.22.0 // indirect
 	golang.org/x/time v0.8.0 // indirect
 	golang.org/x/tools v0.28.0 // indirect
+	google.golang.org/genproto v0.0.0-20241021214115-324edc3d5d38 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20241118233622-e639e219e697 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241209162323-e6fa225c2576 // indirect
 	google.golang.org/grpc v1.67.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -762,6 +762,8 @@ github.com/nrdcg/mailinabox v0.2.0 h1:IKq8mfKiVwNW2hQii/ng1dJ4yYMMv3HAP3fMFIq2CF
 github.com/nrdcg/mailinabox v0.2.0/go.mod h1:0yxqeYOiGyxAu7Sb94eMxHPIOsPYXAjTeA9ZhePhGnc=
 github.com/nrdcg/namesilo v0.2.1 h1:kLjCjsufdW/IlC+iSfAqj0iQGgKjlbUUeDJio5Y6eMg=
 github.com/nrdcg/namesilo v0.2.1/go.mod h1:lwMvfQTyYq+BbjJd30ylEG4GPSS6PII0Tia4rRpRiyw=
+github.com/nrdcg/porkbun v0.4.0 h1:rWweKlwo1PToQ3H+tEO9gPRW0wzzgmI/Ob3n2Guticw=
+github.com/nrdcg/porkbun v0.4.0/go.mod h1:/QMskrHEIM0IhC/wY7iTCUgINsxdT2WcOphktJ9+Q54=
 github.com/nwaples/rardecode/v2 v2.0.0-beta.2 h1:e3mzJFJs4k83GXBEiTaQ5HgSc/kOK8q0rDaRO0MPaOk=
 github.com/nwaples/rardecode/v2 v2.0.0-beta.2/go.mod h1:yntwv/HfMc/Hbvtq9I19D1n58te3h6KsqCf3GxyfBGY=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
@@ -962,8 +964,6 @@ github.com/swaggo/gin-swagger v1.6.0 h1:y8sxvQ3E20/RCyrXeFfg60r6H0Z+SwpTjMYsMm+z
 github.com/swaggo/gin-swagger v1.6.0/go.mod h1:BG00cCEy294xtVpyIAHG6+e2Qzj/xKlRdOqDkvq0uzo=
 github.com/swaggo/swag v1.16.3 h1:PnCYjPCah8FK4I26l2F/KQ4yz3sILcVUN3cTlBFA9Pg=
 github.com/swaggo/swag v1.16.3/go.mod h1:DImHIuOFXKpMFAQjcC7FG4m3Dg4+QuUgUzJmKjI/gRk=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudapp v1.0.1115 h1:y0GrxBKOgY697oJbybR+WBrukZb/RB9bU06BtlPSWVA=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudapp v1.0.1115/go.mod h1:V1xvKmdqEnfD9cfA3z4v/XKxftR4Gdz7Jyp3Oi+UAtM=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.563/go.mod h1:7sCQWVkxcsR38nffDW057DRGk8mUjK1Ing/EFOK8s8Y=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.1065/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.1115 h1:lYeFC379r76seyzN7PHmSxv1ji9knmsXQJglDB/K0WE=


### PR DESCRIPTION
#### What this PR does / why we need it?

This PR adds support for the Porkbun DNS provider for DNS-01 based SSL certificate issuance.  
It allows users to automatically obtain certificates using Porkbun-managed domains via ACME.

> Because Porkbun is a popular and developer-friendly registrar — and honestly, who could say no to a cute pink pig?

#### Summary of your change

- Added Porkbun as a new DNS provider option in the frontend.
- Implemented Porkbun DNS provider integration in the backend using the lego provider.
- Supported API Key and Secret API Key configuration for Porkbun DNS accounts.
- Ensured proper propagation, polling interval, and TTL handling consistent with existing providers.

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of Conventional Commits specification.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.