### PR TITLE
fix: improve compose status sync logic

### DIFF
--- a/frontend/src/components/log/container/index.vue
+++ b/frontend/src/components/log/container/index.vue
@@ -20,7 +20,7 @@
         <el-button class="margin-button" @click="onDownload" icon="Download">
             {{ $t('commons.button.download') }}
         </el-button>
-        <el-button class="margin-button" @click="onClean" icon="Delete" v-if="logSearch.container !== ''">
+        <el-button class="margin-button" @click="onClean" icon="Delete">
             {{ $t('commons.button.clean') }}
         </el-button>
     </div>

--- a/frontend/src/components/log/container/index.vue
+++ b/frontend/src/components/log/container/index.vue
@@ -20,7 +20,7 @@
         <el-button class="margin-button" @click="onDownload" icon="Download">
             {{ $t('commons.button.download') }}
         </el-button>
-        <el-button class="margin-button" @click="onClean" icon="Delete">
+        <el-button class="margin-button" @click="onClean" icon="Delete" v-if="logSearch.container !== ''">
             {{ $t('commons.button.clean') }}
         </el-button>
     </div>

--- a/frontend/src/views/container/compose/index.vue
+++ b/frontend/src/views/container/compose/index.vue
@@ -421,17 +421,20 @@ const handleComposeOperate = async (operation: 'up' | 'stop' | 'restart', row: a
         loading.value = true;
         const params = {
             name: row.name,
-            path: currentCompose.value.path,
+            path: row.path,
             operation: operation,
             withFile: false,
             force: false,
         };
         await composeOperator(params)
-            .then(() => {
+            .then(async () => {
                 MsgSuccess(i18n.global.t('commons.msg.operationSuccess'));
-                search();
-                if (row.name === currentCompose.value?.name) {
-                    loadDetail(currentCompose.value, true);
+                await search();
+                if (currentCompose.value) {
+                    const updated = data.value.find((item) => item.name === currentCompose.value.name);
+                    if (updated) {
+                        await loadDetail(updated, true);
+                    }
                 }
             })
             .finally(() => {
@@ -452,7 +455,13 @@ const onSubmitEdit = async () => {
     await composeUpdate(param)
         .then(async () => {
             MsgSuccess(i18n.global.t('commons.msg.operationSuccess'));
-            await loadDetail(currentCompose.value, true);
+            await search();
+            if (currentCompose.value) {
+                const updated = data.value.find((item) => item.name === currentCompose.value.name);
+                if (updated) {
+                    await loadDetail(updated, true);
+                }
+            }
         })
         .finally(() => {
             loading.value = false;


### PR DESCRIPTION
#### What this PR does / why we need it?
#11242

对 #11238 pr的补充
#### Summary of your change
Commit https://github.com/1Panel-dev/1Panel/pull/11244/commits/cf0ce2db0a2c9da606aaac7714861c8ac4bd05c2
- 每次编排有启停操作或者 compose 文件更新影响到编排启停时，刷新编排和容器状态。避免信息延迟不同步问题
<img width="1666" height="639" alt="image" src="https://github.com/user-attachments/assets/d1dcd652-da6c-4745-a804-2fc6a8e0c5ec" />
#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.