### PR TITLE
fix: Update handling fucntion to ensure detail loading after operations

### DIFF
--- a/frontend/src/views/container/compose/index.vue
+++ b/frontend/src/views/container/compose/index.vue
@@ -441,17 +441,20 @@ const handleComposeOperate = async (operation: 'up' | 'stop' | 'restart', row: a
         loading.value = true;
         const params = {
             name: row.name,
-            path: currentCompose.value.path,
+            path: row.path,
             operation: operation,
             withFile: false,
             force: false,
         };
         await composeOperator(params)
-            .then(() => {
+            .then(async () => {
                 MsgSuccess(i18n.global.t('commons.msg.operationSuccess'));
-                search();
-                if (row.name === currentCompose.value?.name) {
-                    loadDetail(currentCompose.value, true);
+                await search();
+                if (currentCompose.value) {
+                    const updated = data.value.find((item) => item.name === currentCompose.value.name);
+                    if (updated) {
+                        await loadDetail(updated, true);
+                    }
                 }
             })
             .finally(() => {
@@ -480,7 +483,13 @@ const onSubmitEdit = async () => {
     await composeUpdate(param)
         .then(async () => {
             MsgSuccess(i18n.global.t('commons.msg.operationSuccess'));
-            await loadDetail(currentCompose.value, true);
+            await search();
+            if (currentCompose.value) {
+                const updated = data.value.find((item) => item.name === currentCompose.value.name);
+                if (updated) {
+                    await loadDetail(updated, true);
+                }
+            }
         })
         .finally(() => {
             loading.value = false;


### PR DESCRIPTION
#### What this PR does / why we need it?
#11242
修复对编排启停后或者修改compose后，编排面板和编排下容器状态不同步的问题
#### Summary of your change

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.