### PR TITLE
perf: improve getNetConnections function and Websocket handling

### DIFF
--- a/agent/utils/websocket/client.go
+++ b/agent/utils/websocket/client.go
@@ -1,26 +1,32 @@
 package websocket
 
 import (
+	"sync/atomic"
+
 	"github.com/gorilla/websocket"
 )
+
+const MaxMessageQuenue = 32
 
 type Client struct {
 	ID     string
 	Socket *websocket.Conn
 	Msg    chan []byte
+	closed atomic.Bool
 }
 
 func NewWsClient(ID string, socket *websocket.Conn) *Client {
 	return &Client{
 		ID:     ID,
 		Socket: socket,
-		Msg:    make(chan []byte, 100),
+		Msg:    make(chan []byte, 32),
+		closed: atomic.Bool{},
 	}
 }
 
 func (c *Client) Read() {
 	defer func() {
-		close(c.Msg)
+		c.Close()
 	}()
 	for {
 		_, message, err := c.Socket.ReadMessage()
@@ -41,5 +47,21 @@ func (c *Client) Write() {
 			return
 		}
 		_ = c.Socket.WriteMessage(websocket.TextMessage, message)
+	}
+}
+
+func (c *Client) SendPayload(res []byte) {
+	if c.closed.Load() {
+		return
+	}
+	select {
+	case c.Msg <- res:
+		return
+	default:
+		select {
+		case <-c.Msg:
+		default:
+		}
+		c.Msg <- res
 	}
 }

--- a/agent/utils/websocket/client.go
+++ b/agent/utils/websocket/client.go
@@ -1,6 +1,7 @@
 package websocket
 
 import (
+	"sync"
 	"sync/atomic"
 
 	"github.com/gorilla/websocket"
@@ -9,25 +10,31 @@ import (
 const MaxMessageQuenue = 32
 
 type Client struct {
-	ID     string
-	Socket *websocket.Conn
-	Msg    chan []byte
-	closed atomic.Bool
+	ID        string
+	Socket    *websocket.Conn
+	Msg       chan []byte
+	closed    atomic.Bool
+	closeOnce sync.Once
 }
 
 func NewWsClient(ID string, socket *websocket.Conn) *Client {
 	return &Client{
 		ID:     ID,
 		Socket: socket,
-		Msg:    make(chan []byte, 32),
-		closed: atomic.Bool{},
+		Msg:    make(chan []byte, MaxMessageQuenue),
 	}
 }
 
+func (c *Client) Close() {
+	c.closeOnce.Do(func() {
+		c.closed.Store(true)
+		close(c.Msg)
+		c.Socket.Close()
+	})
+}
+
 func (c *Client) Read() {
-	defer func() {
-		c.Close()
-	}()
+	defer c.Close()
 	for {
 		_, message, err := c.Socket.ReadMessage()
 		if err != nil {
@@ -38,9 +45,6 @@ func (c *Client) Read() {
 }
 
 func (c *Client) Write() {
-	defer func() {
-		c.Socket.Close()
-	}()
 	for {
 		message, ok := <-c.Msg
 		if !ok {
@@ -56,12 +60,6 @@ func (c *Client) SendPayload(res []byte) {
 	}
 	select {
 	case c.Msg <- res:
-		return
 	default:
-		select {
-		case <-c.Msg:
-		default:
-		}
-		c.Msg <- res
 	}
 }

--- a/agent/utils/websocket/client.go
+++ b/agent/utils/websocket/client.go
@@ -1,7 +1,6 @@
 package websocket
 
 import (
-	"sync"
 	"sync/atomic"
 
 	"github.com/gorilla/websocket"
@@ -10,11 +9,10 @@ import (
 const MaxMessageQuenue = 32
 
 type Client struct {
-	ID        string
-	Socket    *websocket.Conn
-	Msg       chan []byte
-	closed    atomic.Bool
-	closeOnce sync.Once
+	ID     string
+	Socket *websocket.Conn
+	Msg    chan []byte
+	closed atomic.Bool
 }
 
 func NewWsClient(ID string, socket *websocket.Conn) *Client {
@@ -25,16 +23,11 @@ func NewWsClient(ID string, socket *websocket.Conn) *Client {
 	}
 }
 
-func (c *Client) Close() {
-	c.closeOnce.Do(func() {
+func (c *Client) Read() {
+	defer func() {
 		c.closed.Store(true)
 		close(c.Msg)
-		c.Socket.Close()
-	})
-}
-
-func (c *Client) Read() {
-	defer c.Close()
+	}()
 	for {
 		_, message, err := c.Socket.ReadMessage()
 		if err != nil {
@@ -45,6 +38,7 @@ func (c *Client) Read() {
 }
 
 func (c *Client) Write() {
+	defer c.Socket.Close()
 	for {
 		message, ok := <-c.Msg
 		if !ok {

--- a/agent/utils/websocket/client.go
+++ b/agent/utils/websocket/client.go
@@ -54,7 +54,7 @@ func (c *Client) Write() {
 	}
 }
 
-func (c *Client) SendPayload(res []byte) {
+func (c *Client) Send(res []byte) {
 	if c.closed.Load() {
 		return
 	}

--- a/agent/utils/websocket/process_data.go
+++ b/agent/utils/websocket/process_data.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -320,30 +321,9 @@ func getSSHSessions(config SSHSessionConfig) (res []byte, err error) {
 }
 
 func getNetConnections(config NetConfig) (res []byte, err error) {
-	result := make([]ProcessConnect, 0)
+	result := make([]ProcessConnect, 0, 1024)
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
-
-	processes, err := process.ProcessesWithContext(ctx)
-	if err != nil {
-		res, _ = json.Marshal(result)
-		return
-	}
-
-	procPidMap := make(map[int32]string, len(processes))
-	for _, proc := range processes {
-		name, _ := proc.Name()
-		if name == "" {
-			continue
-		}
-		if config.ProcessName != "" && !strings.Contains(name, config.ProcessName) {
-			continue
-		}
-		if config.ProcessID > 0 && config.ProcessID != proc.Pid {
-			continue
-		}
-		procPidMap[proc.Pid] = name
-	}
 
 	connections, err := net.ConnectionsMaxWithContext(ctx, "all", 32768)
 	if err != nil {
@@ -351,27 +331,68 @@ func getNetConnections(config NetConfig) (res []byte, err error) {
 		return
 	}
 
+	pidConnectionsMap := make(map[int32][]net.ConnectionStat, 256)
+	pidNameMap := make(map[int32]string, 256)
+
 	for _, conn := range connections {
 		if conn.Family != 2 && conn.Family != 10 {
 			continue
 		}
-		if name, ok := procPidMap[conn.Pid]; ok {
-			connType := getConnectionType(conn.Type, conn.Family)
-			if config.Port > 0 && conn.Laddr.Port != config.Port {
+
+		if conn.Pid == 0 {
+			continue
+		}
+
+		if config.ProcessID > 0 && conn.Pid != config.ProcessID {
+			continue
+		}
+
+		if config.Port > 0 && conn.Laddr.Port != config.Port && conn.Raddr.Port != config.Port {
+			continue
+		}
+
+		if _, exists := pidNameMap[conn.Pid]; !exists {
+			pName, _ := getProcessNameWithContext(ctx, conn.Pid)
+			if pName == "" {
 				continue
 			}
+			if config.ProcessName != "" && !strings.Contains(pName, config.ProcessName) {
+				continue
+			}
+			pidNameMap[conn.Pid] = pName
+		}
+
+		pidConnectionsMap[conn.Pid] = append(pidConnectionsMap[conn.Pid], conn)
+	}
+
+	for pid, connections := range pidConnectionsMap {
+		for _, conn := range connections {
 			result = append(result, ProcessConnect{
-				Type:   connType,
+				Type:   getConnectionType(conn.Type, conn.Family),
 				Status: conn.Status,
 				Laddr:  conn.Laddr,
 				Raddr:  conn.Raddr,
 				PID:    conn.Pid,
-				Name:   name,
+				Name:   pidNameMap[pid],
 			})
 		}
 	}
-	res, _ = json.Marshal(result)
+
+	res, err = json.Marshal(result)
 	return
+}
+
+func getProcessNameWithContext(ctx context.Context, pid int32) (string, error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid))
+	if err != nil || len(data) == 0 {
+		p, err := process.NewProcessWithContext(ctx, pid)
+		if err != nil {
+			return "", err
+		}
+		return p.Name()
+	}
+	return strings.TrimSpace(string(data)), nil
+
 }
 
 func getConnectionType(connType uint32, family uint32) string {

--- a/agent/utils/websocket/process_data.go
+++ b/agent/utils/websocket/process_data.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/1Panel-dev/1Panel/agent/utils/common"
 	"github.com/1Panel-dev/1Panel/agent/global"
+	"github.com/1Panel-dev/1Panel/agent/utils/common"
 	"github.com/1Panel-dev/1Panel/agent/utils/files"
 	"github.com/shirou/gopsutil/v4/host"
 	"github.com/shirou/gopsutil/v4/net"
@@ -113,25 +113,25 @@ func ProcessData(c *Client, inputMsg []byte) {
 		if err != nil {
 			return
 		}
-		c.Msg <- res
+		c.SendPayload(res)
 	case "ps":
 		res, err := getProcessData(wsInput.PsProcessConfig)
 		if err != nil {
 			return
 		}
-		c.Msg <- res
+		c.SendPayload(res)
 	case "ssh":
 		res, err := getSSHSessions(wsInput.SSHSessionConfig)
 		if err != nil {
 			return
 		}
-		c.Msg <- res
+		c.SendPayload(res)
 	case "net":
 		res, err := getNetConnections(wsInput.NetConfig)
 		if err != nil {
 			return
 		}
-		c.Msg <- res
+		c.SendPayload(res)
 	}
 
 }
@@ -312,29 +312,36 @@ func getSSHSessions(config SSHSessionConfig) (res []byte, err error) {
 	return
 }
 
-var netTypes = [...]string{"tcp", "udp"}
+var netTypes = [...]string{"tcp", "udp", "tcp6", "udp6"}
 
 func getNetConnections(config NetConfig) (res []byte, err error) {
-	var (
-		result []ProcessConnect
-		proc   *process.Process
-	)
+	ctx := context.Background()
+	processes, err := process.ProcessesWithContext(ctx)
+	if err != nil {
+		return
+	}
+
+	procPidMap := make(map[int32]string, len(processes))
+	for _, proc := range processes {
+		name, _ := proc.Name()
+		if name == "" {
+			continue
+		}
+		if config.ProcessName != "" && !strings.Contains(name, config.ProcessName) {
+			continue
+		}
+		if config.ProcessID > 0 && config.ProcessID != proc.Pid {
+			continue
+		}
+		procPidMap[proc.Pid] = name
+	}
+
+	result := make([]ProcessConnect, 0, len(processes))
 	for _, netType := range netTypes {
-		connections, _ := net.Connections(netType)
+		connections, err := net.ConnectionsWithContext(ctx, netType)
 		if err == nil {
 			for _, conn := range connections {
-				if config.ProcessID > 0 && config.ProcessID != conn.Pid {
-					continue
-				}
-				proc, err = process.NewProcess(conn.Pid)
-				if err == nil {
-					name, _ := proc.Name()
-					if name != "" && config.ProcessName != "" && !strings.Contains(name, config.ProcessName) {
-						continue
-					}
-					if config.Port > 0 && config.Port != conn.Laddr.Port && config.Port != conn.Raddr.Port {
-						continue
-					}
+				if name, ok := procPidMap[conn.Pid]; ok {
 					result = append(result, ProcessConnect{
 						Type:   netType,
 						Status: conn.Status,
@@ -344,10 +351,9 @@ func getNetConnections(config NetConfig) (res []byte, err error) {
 						Name:   name,
 					})
 				}
-
 			}
 		}
 	}
-	res, err = json.Marshal(result)
+	res, _ = json.Marshal(result)
 	return
 }

--- a/agent/utils/websocket/process_data.go
+++ b/agent/utils/websocket/process_data.go
@@ -15,6 +15,8 @@ import (
 	"github.com/shirou/gopsutil/v4/process"
 )
 
+const defaultTimeout = 10 * time.Second
+
 type WsInput struct {
 	Type string `json:"type"`
 	DownloadProgress
@@ -204,7 +206,8 @@ func handleProcessData(proc *process.Process, processConfig *PsProcessConfig, pi
 }
 
 func getProcessData(processConfig PsProcessConfig) (res []byte, err error) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
 
 	processes, err := process.ProcessesWithContext(ctx)
 	if err != nil {
@@ -243,7 +246,10 @@ func getSSHSessions(config SSHSessionConfig) (res []byte, err error) {
 		users     []host.UserStat
 		processes []*process.Process
 	)
-	users, err = host.Users()
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	users, err = host.UsersWithContext(ctx)
 	if err != nil {
 		res, err = json.Marshal(result)
 		return
@@ -268,8 +274,9 @@ func getSSHSessions(config SSHSessionConfig) (res []byte, err error) {
 		return
 	}
 
-	processes, err = process.Processes()
+	processes, err = process.ProcessesWithContext(ctx)
 	if err != nil {
+		res, err = json.Marshal(result)
 		return
 	}
 
@@ -312,12 +319,14 @@ func getSSHSessions(config SSHSessionConfig) (res []byte, err error) {
 	return
 }
 
-var netTypes = [...]string{"tcp", "udp", "tcp6", "udp6"}
-
 func getNetConnections(config NetConfig) (res []byte, err error) {
-	ctx := context.Background()
+	result := make([]ProcessConnect, 0)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
 	processes, err := process.ProcessesWithContext(ctx)
 	if err != nil {
+		res, _ = json.Marshal(result)
 		return
 	}
 
@@ -336,24 +345,46 @@ func getNetConnections(config NetConfig) (res []byte, err error) {
 		procPidMap[proc.Pid] = name
 	}
 
-	result := make([]ProcessConnect, 0, len(processes))
-	for _, netType := range netTypes {
-		connections, err := net.ConnectionsWithContext(ctx, netType)
-		if err == nil {
-			for _, conn := range connections {
-				if name, ok := procPidMap[conn.Pid]; ok {
-					result = append(result, ProcessConnect{
-						Type:   netType,
-						Status: conn.Status,
-						Laddr:  conn.Laddr,
-						Raddr:  conn.Raddr,
-						PID:    conn.Pid,
-						Name:   name,
-					})
-				}
+	connections, err := net.ConnectionsMaxWithContext(ctx, "all", 32768)
+	if err != nil {
+		res, _ = json.Marshal(result)
+		return
+	}
+
+	for _, conn := range connections {
+		if conn.Family != 2 && conn.Family != 10 {
+			continue
+		}
+		if name, ok := procPidMap[conn.Pid]; ok {
+			connType := getConnectionType(conn.Type, conn.Family)
+			if config.Port > 0 && conn.Laddr.Port != config.Port {
+				continue
 			}
+			result = append(result, ProcessConnect{
+				Type:   connType,
+				Status: conn.Status,
+				Laddr:  conn.Laddr,
+				Raddr:  conn.Raddr,
+				PID:    conn.Pid,
+				Name:   name,
+			})
 		}
 	}
 	res, _ = json.Marshal(result)
 	return
+}
+
+func getConnectionType(connType uint32, family uint32) string {
+	switch {
+	case connType == 1 && family == 2:
+		return "tcp"
+	case connType == 1 && family == 10:
+		return "tcp6"
+	case connType == 2 && family == 2:
+		return "udp"
+	case connType == 2 && family == 10:
+		return "udp6"
+	default:
+		return "unknown"
+	}
 }

--- a/agent/utils/websocket/process_data.go
+++ b/agent/utils/websocket/process_data.go
@@ -116,25 +116,25 @@ func ProcessData(c *Client, inputMsg []byte) {
 		if err != nil {
 			return
 		}
-		c.SendPayload(res)
+		c.Send(res)
 	case "ps":
 		res, err := getProcessData(wsInput.PsProcessConfig)
 		if err != nil {
 			return
 		}
-		c.SendPayload(res)
+		c.Send(res)
 	case "ssh":
 		res, err := getSSHSessions(wsInput.SSHSessionConfig)
 		if err != nil {
 			return
 		}
-		c.SendPayload(res)
+		c.Send(res)
 	case "net":
 		res, err := getNetConnections(wsInput.NetConfig)
 		if err != nil {
 			return
 		}
-		c.SendPayload(res)
+		c.Send(res)
 	}
 
 }
@@ -354,10 +354,7 @@ func getNetConnections(config NetConfig) (res []byte, err error) {
 		if _, exists := pidNameMap[conn.Pid]; !exists {
 			pName, _ := getProcessNameWithContext(ctx, conn.Pid)
 			if pName == "" {
-				continue
-			}
-			if config.ProcessName != "" && !strings.Contains(pName, config.ProcessName) {
-				continue
+				pName = "<UNKNOWN>"
 			}
 			pidNameMap[conn.Pid] = pName
 		}
@@ -366,6 +363,10 @@ func getNetConnections(config NetConfig) (res []byte, err error) {
 	}
 
 	for pid, connections := range pidConnectionsMap {
+		pName := pidNameMap[pid]
+		if config.ProcessName != "" && !strings.Contains(pName, config.ProcessName) {
+			continue
+		}
 		for _, conn := range connections {
 			result = append(result, ProcessConnect{
 				Type:   getConnectionType(conn.Type, conn.Family),
@@ -373,7 +374,7 @@ func getNetConnections(config NetConfig) (res []byte, err error) {
 				Laddr:  conn.Laddr,
 				Raddr:  conn.Raddr,
 				PID:    conn.Pid,
-				Name:   pidNameMap[pid],
+				Name:   pName,
 			})
 		}
 	}
@@ -384,15 +385,14 @@ func getNetConnections(config NetConfig) (res []byte, err error) {
 
 func getProcessNameWithContext(ctx context.Context, pid int32) (string, error) {
 	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid))
-	if err != nil || len(data) == 0 {
-		p, err := process.NewProcessWithContext(ctx, pid)
-		if err != nil {
-			return "", err
-		}
-		return p.Name()
+	if err == nil && len(data) > 0 {
+		return strings.TrimSpace(string(data)), nil
 	}
-	return strings.TrimSpace(string(data)), nil
-
+	p, err := process.NewProcessWithContext(ctx, pid)
+	if err != nil {
+		return "", err
+	}
+	return p.Name()
 }
 
 func getConnectionType(connType uint32, family uint32) string {


### PR DESCRIPTION
#### What this PR does / why we need it?

#### Summary of your change
- 优化connection性能，只读一遍网络连接, 后期再判断类型。进程直接优先读 proc 信息拿名称，然后提前建立 Pidmap再后期映射
- 给所有获取进程添加超时机制防止意外情况阻塞
- 减少 websocket的 msg 队列，能阻塞十多个一般来说客户端早就不能消费了，直接对于超出的直接采取丢弃处理。
#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.