### PR TITLE
feat: Enhance browser cache management and localization support

### DIFF
--- a/agent/app/service/website.go
+++ b/agent/app/service/website.go
@@ -1759,10 +1759,12 @@ func (w WebsiteService) OperateProxy(req request.WebsiteProxyConfig) (err error)
 		location.RemoveServerCache(fmt.Sprintf("proxy_cache_zone_of_%s", website.Alias))
 	}
 	// Browser Cache Settings
-	if req.CacheTime != 0 {
+	if req.CacheTime > 0 {
 		location.AddBrowserCache(req.CacheTime, req.CacheUnit)
-	} else {
+	} else if req.CacheTime == 0 {
 		location.RemoveBrowserCache()
+	} else {
+		location.AddBroswerNoCache()
 	}
 	// Content Replace Settings
 	if len(req.Replaces) > 0 {
@@ -1945,10 +1947,8 @@ func (w WebsiteService) GetProxies(id uint) (res []request.WebsiteProxyConfig, e
 		}
 		proxyConfig.ProxyPass = location.ProxyPass
 		proxyConfig.Cache = location.Cache
-		if location.CacheTime > 0 {
-			proxyConfig.CacheTime = location.CacheTime
-			proxyConfig.CacheUnit = location.CacheUint
-		}
+		proxyConfig.CacheTime = location.CacheTime
+		proxyConfig.CacheUnit = location.CacheUint
 		if location.ServerCacheTime > 0 {
 			proxyConfig.ServerCacheTime = location.ServerCacheTime
 			proxyConfig.ServerCacheUnit = location.ServerCacheUint

--- a/agent/utils/nginx/components/location.go
+++ b/agent/utils/nginx/components/location.go
@@ -73,6 +73,12 @@ func NewLocation(directive IDirective) *Location {
 						location.CacheUint = unit
 						location.CacheTime = cacheTime
 					}
+					if di.GetName() == "add_header" && len(di.GetParameters()) >= 2 {
+						if di.GetParameters()[0] == "Cache-Control" && di.GetParameters()[1] == "no-cache" {
+							location.CacheTime = -1
+							location.CacheUint = ""
+						}
+					}
 				}
 			}
 			if params[0] == "(" && params[1] == "$request_method" && params[2] == `=` && params[3] == `'OPTIONS'` && params[4] == ")" {
@@ -274,6 +280,28 @@ func (l *Location) AddBrowserCache(cacheTime int, cacheUint string) {
 	l.CacheUint = cacheUint
 }
 
+func (l *Location) AddBroswerNoCache() {
+	l.RemoveDirective("add_header", []string{"Cache-Control", "no-cache"})
+	l.RemoveDirectiveByFullParams("if", []string{"(", "$uri", "~*", `"\.(gif|png|jpg|css|js|woff|woff2)$"`, ")"})
+	l.RemoveDirectiveByFullParams("if", []string{"(", "$uri", "~*", `"\.(gif|png|jpg|css|js|woff|woff2|jpeg|svg|webp|avif)$"`, ")"})
+	directives := l.GetDirectives()
+	newDir := &Directive{
+		Name:       "if",
+		Parameters: []string{"(", "$uri", "~*", `"\.(gif|png|jpg|css|js|woff|woff2|jpeg|svg|webp|avif)$"`, ")"},
+		Block:      &Block{},
+	}
+	block := &Block{}
+	block.Directives = append(block.Directives, &Directive{
+		Name:       "add_header",
+		Parameters: []string{"Cache-Control", "no-cache"},
+	})
+	newDir.Block = block
+	directives = append(directives, newDir)
+	l.Directives = directives
+	l.CacheTime = -1
+	l.CacheUint = "s"
+}
+
 func (l *Location) AddServerCache(cacheKey string, serverCacheTime int, serverCacheUint string) {
 	l.UpdateDirective("proxy_ignore_headers", []string{"Set-Cookie", "Cache-Control", "expires"})
 	l.UpdateDirective("proxy_cache", []string{cacheKey})
@@ -287,7 +315,7 @@ func (l *Location) AddServerCache(cacheKey string, serverCacheTime int, serverCa
 func (l *Location) RemoveBrowserCache() {
 	l.RemoveDirectiveByFullParams("if", []string{"(", "$uri", "~*", `"\.(gif|png|jpg|css|js|woff|woff2)$"`, ")"})
 	l.RemoveDirectiveByFullParams("if", []string{"(", "$uri", "~*", `"\.(gif|png|jpg|css|js|woff|woff2|jpeg|svg|webp|avif)$"`, ")"})
-	l.UpdateDirective("add_header", []string{"Cache-Control", "no-cache"})
+	l.RemoveDirective("add_header", []string{"Cache-Control", "no-cache"})
 	l.CacheTime = 0
 	l.CacheUint = ""
 }

--- a/frontend/src/lang/modules/en.ts
+++ b/frontend/src/lang/modules/en.ts
@@ -2531,6 +2531,7 @@ const message = {
         antiLeech: 'Anti-leech',
         extends: 'Extension',
         browserCache: 'Browser Cache',
+        noModify: 'No Modify',
         serverCache: 'Server Cache',
         leechLog: 'Record anti-leech log',
         accessDomain: 'Allowed domains',

--- a/frontend/src/lang/modules/es-es.ts
+++ b/frontend/src/lang/modules/es-es.ts
@@ -2523,6 +2523,7 @@ const message = {
         antiLeech: 'Anti-hotlink',
         extends: 'Extensiones',
         browserCache: 'Caché de navegador',
+        noModify: 'No Modificar',
         serverCache: 'Caché del servidor',
         leechLog: 'Registrar logs anti-hotlink',
         accessDomain: 'Dominios permitidos',

--- a/frontend/src/lang/modules/ja.ts
+++ b/frontend/src/lang/modules/ja.ts
@@ -2450,6 +2450,7 @@ const message = {
         antiLeech: '反リーチ',
         extends: '拡大',
         browserCache: 'キャッシュ',
+        noModify: '変更しない',
         serverCache: 'サーバーキャッシュ',
         leechLog: '反リーチログを記録します',
         accessDomain: '許可されたドメイン',

--- a/frontend/src/lang/modules/ko.ts
+++ b/frontend/src/lang/modules/ko.ts
@@ -2407,6 +2407,7 @@ const message = {
         antiLeech: '링크 차단',
         extends: '확장',
         browserCache: '캐시',
+        noModify: '수정 안 함',
         serverCache: '서버 캐시',
         leechLog: '링크 차단 로그 기록',
         accessDomain: '허용된 도메인',

--- a/frontend/src/lang/modules/ms.ts
+++ b/frontend/src/lang/modules/ms.ts
@@ -2504,6 +2504,7 @@ const message = {
         antiLeech: 'Anti-leech',
         extends: 'Pelanjutan',
         browserCache: 'Cache',
+        noModify: 'Tidak Ubah',
         serverCache: 'Cache Pelayan',
         leechLog: 'Rekod log anti-leech',
         accessDomain: 'Domain yang dibenarkan',

--- a/frontend/src/lang/modules/pt-br.ts
+++ b/frontend/src/lang/modules/pt-br.ts
@@ -2507,6 +2507,7 @@ const message = {
         antiLeech: 'Anti-leech',
         extends: 'Extensão',
         browserCache: 'Cache',
+        noModify: 'Não Modificar',
         serverCache: 'Cache do servidor',
         leechLog: 'Registrar log anti-leech',
         accessDomain: 'Domínios permitidos',

--- a/frontend/src/lang/modules/ru.ts
+++ b/frontend/src/lang/modules/ru.ts
@@ -2504,6 +2504,7 @@ const message = {
         antiLeech: 'Анти-лич',
         extends: 'Расширение',
         browserCache: 'Кэш',
+        noModify: 'Не изменять',
         serverCache: 'Кэш сервера',
         leechLog: 'Записывать лог анти-лича',
         accessDomain: 'Разрешенные домены',

--- a/frontend/src/lang/modules/tr.ts
+++ b/frontend/src/lang/modules/tr.ts
@@ -2563,6 +2563,7 @@ const message = {
         antiLeech: 'Sömürü karşıtı',
         extends: 'Uzantı',
         browserCache: 'Önbellek',
+        noModify: 'Değiştirme',
         serverCache: 'Sunucu önbelleği',
         leechLog: 'Sömürü karşıtı günlüğü kaydet',
         accessDomain: 'İzin verilen alan adları',

--- a/frontend/src/lang/modules/zh-Hant.ts
+++ b/frontend/src/lang/modules/zh-Hant.ts
@@ -2354,6 +2354,7 @@ const message = {
         antiLeech: '防盜鏈',
         extends: '副檔名',
         browserCache: '瀏覽器快取',
+        noModify: '不修改',
         serverCache: '伺服器快取',
         leechLog: '記錄防盜鏈日誌',
         accessDomain: '允許的域名',

--- a/frontend/src/lang/modules/zh.ts
+++ b/frontend/src/lang/modules/zh.ts
@@ -2351,6 +2351,7 @@ const message = {
         antiLeech: '防盗链',
         extends: '扩展名',
         browserCache: '浏览器缓存',
+        noModify: '不修改',
         serverCache: '服务器缓存',
         leechLog: '记录防盗链日志',
         accessDomain: '允许的域名',

--- a/frontend/src/views/website/website/config/basic/proxy/create/index.vue
+++ b/frontend/src/views/website/website/config/basic/proxy/create/index.vue
@@ -124,24 +124,31 @@
                         </div>
                         <el-button-group>
                             <el-button
-                                :type="proxy.browserCache ? 'primary' : 'default'"
-                                @click="changeBrowserCache(true)"
+                                :type="proxy.browserCache === 'enable' ? 'primary' : 'default'"
+                                @click="changeBrowserCache('enable')"
                                 size="small"
                             >
                                 {{ $t('commons.button.enable') }}
                             </el-button>
                             <el-button
-                                :type="!proxy.browserCache ? 'primary' : 'default'"
-                                @click="changeBrowserCache(false)"
+                                :type="proxy.browserCache === 'disable' ? 'primary' : 'default'"
+                                @click="changeBrowserCache('disable')"
                                 size="small"
                             >
                                 {{ $t('commons.button.disable') }}
+                            </el-button>
+                            <el-button
+                                :type="proxy.browserCache === 'noModify' ? 'primary' : 'default'"
+                                @click="changeBrowserCache('noModify')"
+                                size="small"
+                            >
+                                {{ $t('website.noModify') }}
                             </el-button>
                         </el-button-group>
                     </div>
 
                     <el-collapse-transition>
-                        <div v-if="proxy.browserCache" class="mt-4 mb-6">
+                        <div v-if="proxy.browserCache === 'enable'" class="mt-4 mb-6">
                             <el-form-item :label="$t('website.browserCacheTime')" prop="cacheTime">
                                 <el-input v-model.number="proxy.cacheTime" maxlength="15" class="!w-64">
                                     <template #append>
@@ -257,8 +264,8 @@ const initData = (): Website.ProxyConfig => ({
     operate: 'create',
     enable: true,
     cache: false,
-    cacheTime: 4,
-    cacheUnit: 'h',
+    cacheTime: 0,
+    cacheUnit: '',
     name: '',
     modifier: '',
     match: '/',
@@ -272,7 +279,7 @@ const initData = (): Website.ProxyConfig => ({
     proxySSLName: '',
     serverCacheTime: 10,
     serverCacheUnit: 'm',
-    browserCache: false,
+    browserCache: 'noModify',
     cors: false,
     allowOrigins: '*',
     allowMethods: 'GET,POST,OPTIONS,PUT,DELETE',
@@ -295,8 +302,12 @@ const acceptParams = (proxyParam: Website.ProxyConfig) => {
     activeTab.value = 'basic';
 
     // Initialize browserCache based on cacheTime value
-    if (proxy.value.browserCache === undefined) {
-        proxy.value.browserCache = proxy.value.cacheTime > 0;
+    if (proxy.value.cacheTime > 0) {
+        proxy.value.browserCache = 'enable';
+    } else if (proxy.value.cacheTime === 0) {
+        proxy.value.browserCache = 'noModify';
+    } else {
+        proxy.value.browserCache = 'disable';
     }
 
     const res = getProtocolAndHost(proxyParam.proxyPass);
@@ -326,11 +337,14 @@ const changeServerCache = (cache: boolean) => {
     }
 };
 
-const changeBrowserCache = (cache: boolean) => {
-    proxy.value.browserCache = cache;
-    if (cache) {
+const changeBrowserCache = (mode: 'enable' | 'disable' | 'noModify') => {
+    proxy.value.browserCache = mode;
+    if (mode === 'enable') {
         proxy.value.cacheTime = 4;
         proxy.value.cacheUnit = 'h';
+    } else if (mode === 'disable') {
+        proxy.value.cacheTime = -1;
+        proxy.value.cacheUnit = '';
     } else {
         proxy.value.cacheTime = 0;
         proxy.value.cacheUnit = '';

--- a/frontend/src/views/website/website/config/basic/proxy/index.vue
+++ b/frontend/src/views/website/website/config/basic/proxy/index.vue
@@ -12,11 +12,11 @@
         <el-table-column :label="$t('website.proxyPass')" prop="proxyPass"></el-table-column>
         <el-table-column :label="$t('website.cache')" prop="cache">
             <template #default="{ row }">
-                <el-tag :type="row.cacheTime > 0 ? 'success' : 'info'">
+                <el-tag class="mr-2" :type="row.cacheTime > 0 ? 'success' : 'info'" v-if="row.cacheTime != 0">
                     {{ $t('website.browserCache') + ':' }}
                     {{ row.cacheTime > 0 ? row.cacheTime + row.cacheUnit : $t('setting.sslDisable') }}
                 </el-tag>
-                <el-tag class="ml-2" :type="row.serverCacheTime > 0 ? 'success' : 'info'">
+                <el-tag :type="row.serverCacheTime > 0 ? 'success' : 'info'">
                     {{ $t('website.serverCache') + ':' }}
                     {{ row.serverCacheTime > 0 ? row.serverCacheTime + row.serverCacheUnit : $t('setting.sslDisable') }}
                 </el-tag>


### PR DESCRIPTION
#### What this PR does / why we need it?
https://github.com/1Panel-dev/1Panel/issues/11273
默认由反向代理的上游负责cache-control 头， openrestry不再添加反向代理的所有缓存策略，浏览器缓存衍生出三个按钮用于支持新逻辑。


状态 | 前端按钮 | cacheTime | 后端保存函数 | 后端解析结果 | Nginx 配置
-- | -- | -- | -- | -- | --
启用缓存 | enable | > 0 | AddBrowserCache | 解析 expires → 正数 | if ($uri ~* ...) { expires 4h; }
不修改 | noModify | = 0 | RemoveBrowserCache | 无配置 → 默认值 0 | 无相关配置
禁用缓存 | disable | = -1 | AddBroswerNoCache | 解析 Cache-Control no-cache → -1 | if ($uri ~* ...) { add_header Cache-Control no-cache; }


#### Summary of your change
- Updated browser cache handling in WebsiteService to include a 'noModify' option.
- Introduced new method AddBroswerNoCache in Location to manage no-cache directives.
- Added localization for 'noModify' in multiple languages.
- Updated frontend to support the new browser cache options in the proxy configuration.

<img width="696" height="517" alt="image" src="https://github.com/user-attachments/assets/1eaf2b92-354d-42ee-80c4-91b9e5ab75a0" />

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.