### PR TITLE
chore: Add TrustedDependencies settings to support bun install

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -92,6 +92,10 @@
         "vite-svg-loader": "^5.1.0",
         "vue-tsc": "^0.29.8"
     },
+    "trustedDependencies": [
+        "@vue-office/docx",
+        "@vue-office/excel"
+    ],
     "overrides": {
         "esbuild": "npm:esbuild-wasm@latest"
     },


### PR DESCRIPTION
#### What this PR does / why we need it?
https://github.com/1Panel-dev/1Panel/issues/9851
把node工具换到bun时发现打包会报错，vue-office的包文件不存在，检查才发现bun为了安全性不会执行非热门库的 postinstall 脚本。导致 bun 工具无法正常打包前端。看了 issue 区之前也有一个反馈，就顺便修一下。
#### Summary of your change
添加 bun 的字段，让 vue-office 的工具链正常执行
https://bun.com/docs/pm/lifecycle#trusteddependencies
#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.