### PR TITLE
feat: add autocomplete attributes for MFA input

### DIFF
--- a/frontend/src/views/login/components/login-form.vue
+++ b/frontend/src/views/login/components/login-form.vue
@@ -16,6 +16,7 @@
                                 size="large"
                                 :placeholder="$t('commons.login.mfaCode')"
                                 v-model.trim="mfaLoginForm.code"
+                                autocomplete="one-time-code"
                                 @input="mfaLogin(true)"
                             ></el-input>
                             <div class="h-1">


### PR DESCRIPTION
#### What this PR does / why we need it?
This improvement allows password managers to detect the field as a OTP input and allows auto-fill the verification code directly from the browser extension or keyboard suggestions.

#### Summary of your change
Add `autocomplete="one-time-code"` to the MFA login input field in `frontend/src/views/login/components/login-form.vue`.

<img width="1547" height="894" alt="image" src="https://github.com/user-attachments/assets/907d1b70-2662-4a27-97ad-a8e5ccba5845" />



#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.