### PR TITLE
fix: Manully validate StreamPorts in StreamConfig to prevent empty values

### DIFF
--- a/agent/app/dto/request/website.go
+++ b/agent/app/dto/request/website.go
@@ -42,7 +42,7 @@ type WebsiteCreate struct {
 }
 
 type StreamConfig struct {
-	StreamPorts string `json:"streamPorts" validate:"required"`
+	StreamPorts string `json:"streamPorts"`
 	Name        string `json:"name"`
 	Algorithm   string `json:"algorithm"`
 

--- a/agent/app/service/website.go
+++ b/agent/app/service/website.go
@@ -282,6 +282,9 @@ func (w WebsiteService) CreateWebsite(create request.WebsiteCreate) (err error) 
 		primaryDomain string
 	)
 	if website.Type == constant.Stream {
+		if create.StreamConfig.StreamPorts == "" {
+			return buserr.New("ErrTypePortRange")
+		}
 		website.PrimaryDomain = create.Name
 		website.Protocol = constant.ProtocolStream
 		website.StreamPorts = create.StreamConfig.StreamPorts
@@ -2400,6 +2403,9 @@ func (w WebsiteService) ExecComposer(req request.ExecComposerReq) error {
 }
 
 func (w WebsiteService) UpdateStream(req request.StreamUpdate) error {
+	if req.StreamConfig.StreamPorts == ""{
+		return buserr.New("ErrTypePortRange")
+	}
 	website, err := websiteRepo.GetFirst(repo.WithByID(req.WebsiteID))
 	if err != nil {
 		return err

--- a/agent/app/service/website_utils.go
+++ b/agent/app/service/website_utils.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/1Panel-dev/1Panel/agent/utils/xpack"
 	"log"
 	"net"
 	"os"
@@ -14,6 +13,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/1Panel-dev/1Panel/agent/utils/xpack"
 
 	"github.com/1Panel-dev/1Panel/agent/app/repo"
 
@@ -189,6 +190,9 @@ func configDefaultNginx(website *model.Website, domains []model.WebsiteDomain, a
 		config     *components.Config
 	)
 	if website.Type == constant.Stream {
+		if streamConfig.StreamPorts == "" {
+			return buserr.New("ErrTypePortRange")
+		}
 		nginxContent := nginx_conf.GetWebsiteFile("stream_default.conf")
 		config, err = parser.NewStringParser(string(nginxContent)).Parse()
 		if err != nil {


### PR DESCRIPTION
#### What this PR does / why we need it?
fix https://github.com/1Panel-dev/1Panel/pull/11302
当前代码创建非tcpudp代理的网站，会因为streamport是空值导致验证错误
<img width="598" height="509" alt="image" src="https://github.com/user-attachments/assets/efef30ce-3ff8-4f77-8b78-3d82d81ef108" />

#### Summary of your change
改变该值，允许为空
在使用该值的地方加入空字符串校验，为空报错

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.