### PR TITLE
feat: Add UDP port 443 accept rule to Pre-firewall config

### DIFF
--- a/agent/app/service/firewall.go
+++ b/agent/app/service/firewall.go
@@ -711,6 +711,9 @@ func (u *FirewallService) addPortsBeforeStart(client firewall.FirewallClient) er
 	if err := client.Port(fireClient.FireInfo{Port: "443", Protocol: "tcp", Strategy: "accept"}, "add"); err != nil {
 		return err
 	}
+	if err := client.Port(fireClient.FireInfo{Port: "443", Protocol: "udp", Strategy: "accept"}, "add"); err != nil {
+		return err
+	}
 
 	return client.Reload()
 }

--- a/agent/app/service/iptables.go
+++ b/agent/app/service/iptables.go
@@ -363,6 +363,9 @@ func initPreRules() error {
 			return err
 		}
 	}
+	if err := iptables.AddRule(iptables.FilterTab, iptables.Chain1PanelBasicAfter, fmt.Sprintf("-p udp -m udp --dport 443 -j ACCEPT")); err != nil {
+		return err
+	}
 	if err := iptables.AddRule(iptables.FilterTab, iptables.Chain1PanelBasicAfter, iptables.DropAllTcp); err != nil {
 		return err
 	}


### PR DESCRIPTION
#### What this PR does / why we need it?
<img width="928" height="268" alt="image" src="https://github.com/user-attachments/assets/c6e97eef-8452-4903-8916-1ff9690edd4f" />

OpenResty的http/3 是基于quic = udp 443的 ，防火墙应该默认放通, 不然没用
#### Summary of your change

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.