### PR TITLE
fix: add missing intermediate certificates for IP certificate requests

### DIFF
--- a/agent/utils/ssl/client.go
+++ b/agent/utils/ssl/client.go
@@ -121,6 +121,7 @@ func (c *AcmeClient) ObtainIPSSL(ipAddress string, privKey crypto.PrivateKey) (c
 		CSR:        csr,
 		PrivateKey: privKey,
 		Profile:    "shortlived",
+		Bundle:     true,
 	}
 	certificates, err := c.Client.Certificate.ObtainForCSR(req)
 	if err != nil {


### PR DESCRIPTION
Refs https://github.com/1Panel-dev/1Panel/issues/11462