### PR TITLE
refactor: enhance Mux connection handling in server

### DIFF
--- a/core/server/server.go
+++ b/core/server/server.go
@@ -192,7 +192,7 @@ func handleMuxHttpConn(conn net.Conn) {
 		return
 	}
 
-	if len(req.RequestURI) > 256 {
+	if len(req.RequestURI) > 4096 {
 		return
 	}
 

--- a/core/server/server.go
+++ b/core/server/server.go
@@ -99,6 +99,7 @@ func Start() {
 		constant.CertStore.Store(loadCert())
 
 		server.TLSConfig = &tls.Config{
+			NextProtos: []string{"h2", "http/1.1"},
 			GetCertificate: func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
 				return constant.CertStore.Load().(*tls.Certificate), nil
 			},
@@ -203,7 +204,7 @@ func handleMuxHttpConn(conn net.Conn) {
 	target := "https://" + req.Host + req.URL.RequestURI()
 
 	resp := &http.Response{
-		StatusCode: http.StatusTemporaryRedirect, // 307
+		StatusCode: http.StatusTemporaryRedirect,
 		Proto:      "HTTP/1.1",
 		ProtoMajor: 1,
 		ProtoMinor: 1,

--- a/core/server/server.go
+++ b/core/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bufio"
 	"crypto/tls"
 	"encoding/gob"
 	"fmt"
@@ -8,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/1Panel-dev/1Panel/core/init/auth"
@@ -80,21 +82,7 @@ func Start() {
 		*net.TCPListener
 	}
 	if global.CONF.Conn.SSL == constant.StatusEnable {
-		certPath := path.Join(global.CONF.Base.InstallDir, "1panel/secret/server.crt")
-		keyPath := path.Join(global.CONF.Base.InstallDir, "1panel/secret/server.key")
-		certificate, err := os.ReadFile(certPath)
-		if err != nil {
-			panic(err)
-		}
-		key, err := os.ReadFile(keyPath)
-		if err != nil {
-			panic(err)
-		}
-		cert, err := tls.X509KeyPair(certificate, key)
-		if err != nil {
-			panic(err)
-		}
-		constant.CertStore.Store(&cert)
+		constant.CertStore.Store(loadCert())
 
 		server.TLSConfig = &tls.Config{
 			GetCertificate: func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
@@ -108,21 +96,7 @@ func Start() {
 		}
 		return
 	} else if global.CONF.Conn.SSL == constant.StatusMux {
-		certPath := path.Join(global.CONF.Base.InstallDir, "1panel/secret/server.crt")
-		keyPath := path.Join(global.CONF.Base.InstallDir, "1panel/secret/server.key")
-		certificate, err := os.ReadFile(certPath)
-		if err != nil {
-			panic(err)
-		}
-		key, err := os.ReadFile(keyPath)
-		if err != nil {
-			panic(err)
-		}
-		cert, err := tls.X509KeyPair(certificate, key)
-		if err != nil {
-			panic(err)
-		}
-		constant.CertStore.Store(&cert)
+		constant.CertStore.Store(loadCert())
 
 		server.TLSConfig = &tls.Config{
 			GetCertificate: func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
@@ -130,12 +104,11 @@ func Start() {
 			},
 		}
 
-		global.LOG.Infof("listen at mux (http/https)://%s:%s [%s]", global.CONF.Conn.BindAddress, global.CONF.Conn.Port, tcpItem)
-
 		m := cmux.New(ln)
 
 		httpsL := m.Match(cmux.TLS())
-		httpL := m.Match(cmux.Any())
+		httpL := m.Match(cmux.HTTP1Fast())
+		anyL := m.Match(cmux.Any())
 
 		go func() {
 			if err := server.Serve(tls.NewListener(httpsL, server.TLSConfig)); err != nil {
@@ -144,16 +117,26 @@ func Start() {
 		}()
 
 		go func() {
-			redirectServer := &http.Server{
-				Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					target := "https://" + r.Host + r.RequestURI
-					http.Redirect(w, r, target, http.StatusTemporaryRedirect)
-				}),
-			}
-			if err := redirectServer.Serve(httpL); err != nil {
-				global.LOG.Errorf("HTTP Redirect Serve Error: %v", err)
+			for {
+				conn, err := httpL.Accept()
+				if err != nil {
+					return
+				}
+				go handleMuxHttpConn(conn)
 			}
 		}()
+
+		go func() {
+			for {
+				conn, err := anyL.Accept()
+				if err != nil {
+					return
+				}
+				conn.Close()
+			}
+		}()
+
+		global.LOG.Infof("listen at mux (http/https)://%s:%s [%s]", global.CONF.Conn.BindAddress, global.CONF.Conn.Port, tcpItem)
 
 		if err := m.Serve(); err != nil {
 			panic(err)
@@ -166,4 +149,69 @@ func Start() {
 		}
 		return
 	}
+}
+
+func loadCert() *tls.Certificate {
+	certPath := path.Join(global.CONF.Base.InstallDir, "1panel/secret/server.crt")
+	keyPath := path.Join(global.CONF.Base.InstallDir, "1panel/secret/server.key")
+	certificate, err := os.ReadFile(certPath)
+	if err != nil {
+		panic(err)
+	}
+	key, err := os.ReadFile(keyPath)
+	if err != nil {
+		panic(err)
+	}
+	cert, err := tls.X509KeyPair(certificate, key)
+	if err != nil {
+		panic(err)
+	}
+	return &cert
+}
+
+func handleMuxHttpConn(conn net.Conn) {
+	defer conn.Close()
+
+	req, err := http.ReadRequest(bufio.NewReader(conn))
+	if err != nil {
+		return
+	}
+
+	if req.Host == "" {
+		return
+	}
+
+	ua := req.Header.Get("User-Agent")
+	if ua == "" {
+		return
+	}
+
+	switch req.Method {
+	case http.MethodGet, http.MethodHead, http.MethodPost:
+	default:
+		return
+	}
+
+	if len(req.RequestURI) > 256 {
+		return
+	}
+
+	if !strings.HasPrefix(req.URL.Path, "/") {
+		return
+	}
+
+	target := "https://" + req.Host + req.URL.RequestURI()
+
+	resp := &http.Response{
+		StatusCode: http.StatusTemporaryRedirect, // 307
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header:     make(http.Header),
+	}
+	resp.Header.Set("Location", target)
+	resp.Header.Set("Connection", "close")
+
+	_ = resp.Write(conn)
+	return
 }


### PR DESCRIPTION
#### What this PR does / why we need it?
改进 HTTPS Mux 模式的运行逻辑
仅对http流量去匹配http mux服务，对于其他非http/https流量直接关闭，减少如果被扫的情况下浪费的。链接资源
http跳转服务尽可能检查来源是否来自于真人， 通过后进行 307 后立刻关闭链接，避免浏览器 keep-alive, 或者扫描器占用资源 （虽然开销很低） 

修复 mux 模式下 为了包装 cmux 的 tls 链接导致 h2 失效的问题
#### Summary of your change

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.