### PR TITLE
feat: add support for Porkbun DNS provider

### DIFF
--- a/agent/go.mod
+++ b/agent/go.mod
@@ -195,6 +195,7 @@ require (
 	github.com/nrdcg/freemyip v0.3.0 // indirect
 	github.com/nrdcg/goacmedns v0.2.0 // indirect
 	github.com/nrdcg/namesilo v0.5.0 // indirect
+	github.com/nrdcg/porkbun v0.4.0 // indirect
 	github.com/nwaples/rardecode/v2 v2.2.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/ovh/go-ovh v1.9.0 // indirect

--- a/agent/go.sum
+++ b/agent/go.sum
@@ -764,6 +764,8 @@ github.com/nrdcg/goacmedns v0.2.0 h1:ADMbThobzEMnr6kg2ohs4KGa3LFqmgiBA22/6jUWJR0
 github.com/nrdcg/goacmedns v0.2.0/go.mod h1:T5o6+xvSLrQpugmwHvrSNkzWht0UGAwj2ACBMhh73Cg=
 github.com/nrdcg/namesilo v0.5.0 h1:6QNxT/XxE+f5B+7QlfWorthNzOzcGlBLRQxqi6YeBrE=
 github.com/nrdcg/namesilo v0.5.0/go.mod h1:4UkwlwQfDt74kSGmhLaDylnBrD94IfflnpoEaj6T2qw=
+github.com/nrdcg/porkbun v0.4.0 h1:rWweKlwo1PToQ3H+tEO9gPRW0wzzgmI/Ob3n2Guticw=
+github.com/nrdcg/porkbun v0.4.0/go.mod h1:/QMskrHEIM0IhC/wY7iTCUgINsxdT2WcOphktJ9+Q54=
 github.com/nwaples/rardecode/v2 v2.2.0 h1:4ufPGHiNe1rYJxYfehALLjup4Ls3ck42CWwjKiOqu0A=
 github.com/nwaples/rardecode/v2 v2.2.0/go.mod h1:7uz379lSxPe6j9nvzxUZ+n7mnJNgjsRNb6IbvGVHRmw=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=

--- a/agent/utils/ssl/dns_provider.go
+++ b/agent/utils/ssl/dns_provider.go
@@ -19,6 +19,7 @@ import (
 	"github.com/go-acme/lego/v4/providers/dns/namedotcom"
 	"github.com/go-acme/lego/v4/providers/dns/namesilo"
 	"github.com/go-acme/lego/v4/providers/dns/ovh"
+	"github.com/go-acme/lego/v4/providers/dns/porkbun"
 	"github.com/go-acme/lego/v4/providers/dns/rainyun"
 	"github.com/go-acme/lego/v4/providers/dns/regru"
 	"github.com/go-acme/lego/v4/providers/dns/route53"
@@ -57,6 +58,7 @@ const (
 	BaiduCloud   DnsType = "BaiduCloud"
 	Ovh          DnsType = "Ovh"
 	AcmeDNS      DnsType = "AcmeDNS"
+	PorkBun      DnsType = "PorkBun"
 )
 
 type DNSParam struct {
@@ -291,6 +293,14 @@ func getDNSProviderConfig(dnsType DnsType, params string) (challenge.Provider, e
 		config.APIBase = param.Endpoint
 		config.StorageBaseURL = param.BaseURL
 		p, err = acmedns.NewDNSProviderConfig(config)
+	case PorkBun:
+		config := porkbun.NewDefaultConfig()
+		config.APIKey = param.APIkey
+		config.SecretAPIKey = param.SecretKey
+		config.PropagationTimeout = propagationTimeout
+		config.PollingInterval = pollingInterval
+		config.TTL = ttl
+		p, err = porkbun.NewDNSProviderConfig(config)
 	}
 
 	if err != nil {

--- a/frontend/src/global/mimetype.ts
+++ b/frontend/src/global/mimetype.ts
@@ -265,6 +265,10 @@ export const DNSTypes = [
         value: 'Volcengine',
     },
     {
+        label: 'PorkBun',
+        value: 'PorkBun',
+    },
+    {
         label: 'DNSPod (' + i18n.global.t('ssl.deprecated') + ')',
         value: 'DnsPod',
     },

--- a/frontend/src/views/website/ssl/dns-account/create/index.vue
+++ b/frontend/src/views/website/ssl/dns-account/create/index.vue
@@ -175,6 +175,14 @@
                             <el-input v-model.trim="account.authorization['endpoint']"></el-input>
                         </el-form-item>
                     </div>
+                    <div v-if="account.type === 'PorkBun'">
+                        <el-form-item label="API Key" prop="authorization.apiKey">
+                            <el-input v-model.trim="account.authorization['apiKey']"></el-input>
+                        </el-form-item>
+                        <el-form-item label="Secret Key" prop="authorization.secretKey">
+                            <el-input v-model.trim="account.authorization['secretKey']"></el-input>
+                        </el-form-item>
+                    </div>
                 </el-form>
             </el-col>
         </el-row>


### PR DESCRIPTION
> From PR https://github.com/1Panel-dev/1Panel/pull/11233
> I forgot to push to the v2 branch, then I spent quite a while looking for the provider on another v2 server

#### What this PR does / why we need it?

This PR adds support for the Porkbun DNS provider for DNS-01 based SSL certificate issuance.  
It allows users to automatically obtain certificates using Porkbun-managed domains via ACME.

> Because Porkbun is a popular and developer-friendly registrar — and honestly, who could say no to a cute pink pig?

#### Summary of your change

- Added Porkbun as a new DNS provider option in the frontend.
- Implemented Porkbun DNS provider integration in the backend using the lego provider.
- Supported API Key and Secret API Key configuration for Porkbun DNS accounts.
- Ensured proper propagation, polling interval, and TTL handling consistent with existing providers.

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of Conventional Commits specification.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.