### PR TITLE
feat: Support batch import for Docker images

### DIFF
--- a/agent/app/dto/image.go
+++ b/agent/app/dto/image.go
@@ -21,8 +21,8 @@ type ImageInfo struct {
 }
 
 type ImageLoad struct {
-	TaskID string `json:"taskID"`
-	Path   string `json:"path" validate:"required"`
+	TaskID string   `json:"taskID"`
+	Paths  []string `json:"paths" validate:"required,dive,required"`
 }
 
 type ImageBuild struct {

--- a/agent/app/service/image.go
+++ b/agent/app/service/image.go
@@ -321,35 +321,41 @@ func (u *ImageService) ImagePull(req dto.ImagePull) error {
 }
 
 func (u *ImageService) ImageLoad(req dto.ImageLoad) error {
-	taskItem, err := task.NewTaskWithOps(req.Path, task.TaskImport, task.TaskScopeImage, req.TaskID, 1)
+	taskItem, err := task.NewTaskWithOps(strings.Join(req.Paths, ","), task.TaskImport, task.TaskScopeImage, req.TaskID, 1)
 	if err != nil {
 		return fmt.Errorf("new task for image import failed, err: %v", err)
 	}
-	taskItem.AddSubTask(i18n.GetWithName("TaskImport", req.Path), func(t *task.Task) error {
-		file, err := os.Open(req.Path)
-		if err != nil {
-			return err
-		}
-		defer file.Close()
-		client, err := docker.NewDockerClient()
-		if err != nil {
-			return err
-		}
-		defer client.Close()
-		res, err := client.ImageLoad(context.TODO(), file)
-		if err != nil {
-			return err
-		}
-		defer res.Body.Close()
-		content, err := io.ReadAll(res.Body)
-		if err != nil {
-			return err
-		}
-		if strings.Contains(string(content), "Error") {
-			return errors.New(string(content))
-		}
-		return nil
-	}, nil)
+
+	for _, itemPath := range req.Paths {
+		currentPath := itemPath
+		itemName := path.Base(currentPath)
+		taskItem.AddSubTask(i18n.GetWithName("TaskImport", itemName), func(t *task.Task) error {
+			taskItem.Logf("----------------- %s -----------------", itemName)
+			file, err := os.Open(currentPath)
+			if err != nil {
+				return err
+			}
+			defer file.Close()
+			client, err := docker.NewDockerClient()
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+			res, err := client.ImageLoad(context.TODO(), file)
+			if err != nil {
+				return err
+			}
+			defer res.Body.Close()
+			content, err := io.ReadAll(res.Body)
+			if err != nil {
+				return err
+			}
+			if strings.Contains(string(content), "Error") {
+				return errors.New(string(content))
+			}
+			return nil
+		}, nil)
+	}
 	go func() {
 		_ = taskItem.Execute()
 	}()

--- a/agent/app/service/image.go
+++ b/agent/app/service/image.go
@@ -326,37 +326,39 @@ func (u *ImageService) ImageLoad(req dto.ImageLoad) error {
 		return fmt.Errorf("new task for image import failed, err: %v", err)
 	}
 
-	for _, itemPath := range req.Paths {
-		currentPath := itemPath
-		itemName := path.Base(currentPath)
-		taskItem.AddSubTask(i18n.GetWithName("TaskImport", itemName), func(t *task.Task) error {
-			taskItem.Logf("----------------- %s -----------------", itemName)
-			file, err := os.Open(currentPath)
-			if err != nil {
-				return err
-			}
-			defer file.Close()
-			client, err := docker.NewDockerClient()
-			if err != nil {
-				return err
-			}
-			defer client.Close()
-			res, err := client.ImageLoad(context.TODO(), file)
-			if err != nil {
-				return err
-			}
-			defer res.Body.Close()
-			content, err := io.ReadAll(res.Body)
-			if err != nil {
-				return err
-			}
-			if strings.Contains(string(content), "Error") {
-				return errors.New(string(content))
-			}
-			return nil
-		}, nil)
-	}
 	go func() {
+		client, err := docker.NewDockerClient()
+		if err != nil {
+			taskItem.Log("Failed to create Docker client: " + err.Error())
+			return
+		}
+		defer client.Close()
+
+		for _, itemPath := range req.Paths {
+			currentPath := itemPath
+			itemName := path.Base(currentPath)
+			taskItem.AddSubTask(i18n.GetWithName("TaskImport", itemName), func(t *task.Task) error {
+				taskItem.Logf("----------------- %s -----------------", itemName)
+				file, err := os.Open(currentPath)
+				if err != nil {
+					return err
+				}
+				defer file.Close()
+				res, err := client.ImageLoad(context.TODO(), file)
+				if err != nil {
+					return err
+				}
+				defer res.Body.Close()
+				content, err := io.ReadAll(res.Body)
+				if err != nil {
+					return err
+				}
+				if strings.Contains(string(content), "Error") {
+					return errors.New(string(content))
+				}
+				return nil
+			}, nil)
+		}
 		_ = taskItem.Execute()
 	}()
 	return nil

--- a/frontend/src/api/interface/container.ts
+++ b/frontend/src/api/interface/container.ts
@@ -224,7 +224,7 @@ export namespace Container {
     }
     export interface ImageLoad {
         taskID: string;
-        path: string;
+        paths: Array<string>;
     }
     export interface ImageSave {
         taskID: string;

--- a/frontend/src/components/file-list/index.vue
+++ b/frontend/src/components/file-list/index.vue
@@ -105,7 +105,8 @@
             </el-table>
         </div>
         <div class="file-list-bottom">
-            <div v-if="selectRow?.path">
+            <!-- Single select mode -->
+            <div v-if="!isMultiple && selectRow?.path">
                 {{ $t('file.currentSelect') }}
                 <el-tooltip :content="selectRow.path" placement="top">
                     <el-tag type="success">
@@ -114,6 +115,24 @@
                         </div>
                     </el-tag>
                 </el-tooltip>
+            </div>
+            <!-- Multiple select mode -->
+            <div v-if="isMultiple && selectRows.length > 0">
+                {{ $t('file.currentSelect') }}
+                <el-tag
+                    v-for="(item, index) in selectRows"
+                    :key="item.path"
+                    type="success"
+                    closable
+                    class="mr-1 mb-1"
+                    @close="removeSelected(index)"
+                >
+                    <el-tooltip :content="item.path" placement="top">
+                        <div class="path">
+                            <span>{{ item.path }}</span>
+                        </div>
+                    </el-tooltip>
+                </el-tag>
             </div>
         </div>
 
@@ -142,6 +161,8 @@ const loading = ref(false);
 const paths = ref<string[]>([]);
 const req = reactive({ path: '/', expand: true, page: 1, pageSize: 300, showHidden: true });
 const selectRow = ref({ path: '', name: '' });
+const selectRows = ref<Array<{ path: string; name: string }>>([]);
+const isMultiple = ref(false);
 const rowRefs = ref();
 const open = ref(false);
 const newFolder = ref();
@@ -160,16 +181,20 @@ const form = reactive({
 });
 
 interface DialogProps {
-    path: string;
+    path?: string;
     dir: boolean;
-    isAll: boolean;
-    disabled: boolean;
+    isAll?: boolean;
+    disabled?: boolean;
+    multiple?: boolean;
 }
 const acceptParams = (props: DialogProps): void => {
     form.path = props.path || '/';
     form.dir = props.dir;
-    form.isAll = props.isAll;
-    form.disabled = props.disabled;
+    form.isAll = props.isAll || false;
+    form.disabled = props.disabled || false;
+    isMultiple.value = props.multiple || false;
+    selectRows.value = [];
+    selectRow.value = { path: '', name: '' };
     openPage();
     req.path = form.path;
     oldUrl.value = form.path;
@@ -178,8 +203,15 @@ const acceptParams = (props: DialogProps): void => {
 };
 
 const selectFile = () => {
-    if (selectRow.value) {
-        em('choose', selectRow.value.path);
+    if (isMultiple.value) {
+        em(
+            'choose',
+            selectRows.value.map((r) => r.path),
+        );
+    } else {
+        if (selectRow.value) {
+            em('choose', selectRow.value.path);
+        }
     }
     handleClose();
 };
@@ -187,6 +219,7 @@ const selectFile = () => {
 const handleClose = () => {
     open.value = false;
     selectRow.value = { path: '', name: '' };
+    selectRows.value = [];
 };
 
 const openPage = () => {
@@ -221,8 +254,21 @@ const openDir = async (row: File.File, column: any, event: any) => {
             });
         return;
     }
+    // Handle file click
+    const fullPath = (req.path === '/' ? req.path : req.path + '/') + row.name;
+    if (isMultiple.value) {
+        // Multiple mode: toggle selection
+        const index = selectRows.value.findIndex((r) => r.path === fullPath);
+        if (index > -1) {
+            selectRows.value.splice(index, 1);
+        } else {
+            selectRows.value.push({ path: fullPath, name: row.name });
+        }
+        return;
+    }
+    // Single mode: original behavior
     if (form.isAll || !form.dir) {
-        selectRow.value.path = (req.path === '/' ? req.path : req.path + '/') + row.name;
+        selectRow.value.path = fullPath;
         return;
     }
     selectRow.value.path = '';
@@ -418,6 +464,10 @@ onUpdated(() => {
     }
     search(req);
 });
+
+const removeSelected = (index: number) => {
+    selectRows.value.splice(index, 1);
+};
 
 defineExpose({
     acceptParams,

--- a/frontend/src/components/file-list/index.vue
+++ b/frontend/src/components/file-list/index.vue
@@ -105,7 +105,6 @@
             </el-table>
         </div>
         <div class="file-list-bottom">
-            <!-- Single select mode -->
             <div v-if="!isMultiple && selectRow?.path">
                 {{ $t('file.currentSelect') }}
                 <el-tooltip :content="selectRow.path" placement="top">
@@ -116,7 +115,6 @@
                     </el-tag>
                 </el-tooltip>
             </div>
-            <!-- Multiple select mode -->
             <div v-if="isMultiple && selectRows.length > 0">
                 {{ $t('file.currentSelect') }}
                 <el-tag

--- a/frontend/src/views/container/image/load/index.vue
+++ b/frontend/src/views/container/image/load/index.vue
@@ -4,7 +4,7 @@
             <el-form-item :label="$t('container.path')" :rules="Rules.requiredInput" prop="path">
                 <el-input v-model="form.path">
                     <template #prepend>
-                        <el-button icon="Folder" @click="fileRef.acceptParams({ dir: false })" />
+                        <el-button icon="Folder" @click="fileRef.acceptParams({ dir: false, multiple: true })" />
                     </template>
                 </el-input>
             </el-form-item>
@@ -42,12 +42,14 @@ const taskLogRef = ref();
 const loadVisible = ref(false);
 const form = reactive({
     path: '',
+    paths: [] as string[],
     taskID: '',
 });
 
 const acceptParams = () => {
     loadVisible.value = true;
     form.path = '';
+    form.paths = [];
 };
 const handleClose = () => {
     loadVisible.value = false;
@@ -64,7 +66,7 @@ const onSubmit = async (formEl: FormInstance | undefined) => {
         if (!valid) return;
         loading.value = true;
         form.taskID = newUUID();
-        await imageLoad(form)
+        await imageLoad({ paths: form.paths, taskID: form.taskID })
             .then(() => {
                 loading.value = false;
                 loadVisible.value = false;
@@ -82,8 +84,10 @@ const openTaskLog = (taskID: string) => {
     taskLogRef.value.openWithTaskID(taskID);
 };
 
-const loadLoadDir = async (path: string) => {
-    form.path = path;
+const loadLoadDir = async (paths: string | string[]) => {
+    const newPaths = Array.isArray(paths) ? paths : [paths];
+    form.paths = [...new Set([...form.paths, ...newPaths])];
+    form.path = form.paths.join('; ');
 };
 
 defineExpose({


### PR DESCRIPTION
#### What this PR does / why we need it?
Refs #11634

#### Summary of your change
Backend (Agent):
- Modified ImageLoad DTO to accept an array of paths (Paths []string) instead of a single path
- Updated the image service to iterate through multiple files and create subtasks for each import operation

Frontend:
- Added multiple prop support to the FileList component for multi-file selection
- Enabled multi-select mode in the image load dialog by passing multiple: true

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e5d66e11-c3d3-485c-8a27-a7ee5a7da1eb" />

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
