### PR TITLE
feat: Add pullImage option to ComposeCreate to swith pull operation

### DIFF
--- a/agent/app/dto/container.go
+++ b/agent/app/dto/container.go
@@ -272,13 +272,14 @@ type ComposeContainer struct {
 	Ports       []string `json:"ports"`
 }
 type ComposeCreate struct {
-	TaskID   string `json:"taskID"`
-	Name     string `json:"name"`
-	From     string `json:"from" validate:"required,oneof=edit path template"`
-	File     string `json:"file"`
-	Path     string `json:"path"`
-	Template uint   `json:"template"`
-	Env      string `json:"env"`
+	TaskID    string `json:"taskID"`
+	Name      string `json:"name"`
+	From      string `json:"from" validate:"required,oneof=edit path template"`
+	File      string `json:"file"`
+	Path      string `json:"path"`
+	Template  uint   `json:"template"`
+	Env       string `json:"env"`
+	PullImage *bool  `json:"pullImage,omitempty"`
 }
 type ComposeOperation struct {
 	Name      string `json:"name" validate:"required"`

--- a/agent/app/service/container_compose.go
+++ b/agent/app/service/container_compose.go
@@ -203,9 +203,13 @@ func (u *ContainerService) CreateCompose(req dto.ComposeCreate) error {
 	if err := newComposeEnv(req.Path, req.Env); err != nil {
 		return err
 	}
+	pullImages := true
+	if req.PullImage != nil {
+		pullImages = *req.PullImage
+	}
 	go func() {
 		taskItem.AddSubTask(i18n.GetMsgByKey("ComposeCreate"), func(t *task.Task) error {
-			err := compose.UpWithTask(req.Path, t)
+			err := compose.UpWithTask(req.Path, t, pullImages)
 			t.LogWithStatus(i18n.GetMsgByKey("ComposeCreate"), err)
 			if err != nil {
 				_, _ = compose.Down(req.Path)

--- a/agent/utils/compose/compose.go
+++ b/agent/utils/compose/compose.go
@@ -36,7 +36,10 @@ func Up(filePath string) (string, error) {
 	return cmd.NewCommandMgr(cmd.WithTimeout(20*time.Minute)).RunWithStdoutBashCf("%s %s up -d", global.CONF.DockerConfig.Command, loadFiles(filePath))
 }
 
-func UpWithTask(filePath string, task *task.Task) error {
+func UpWithTask(filePath string, task *task.Task, pullImages bool) error {
+	if !pullImages {
+		return cmd.NewCommandMgr(cmd.WithTask(*task)).RunBashCf("%s %s up -d", global.CONF.DockerConfig.Command, loadFiles(filePath))
+	}
 	content, err := os.ReadFile(filePath)
 	if err != nil {
 		return err

--- a/frontend/src/api/interface/container.ts
+++ b/frontend/src/api/interface/container.ts
@@ -328,6 +328,8 @@ export namespace Container {
         file: string;
         path: string;
         template: number;
+        env: string;
+        pullImage?: boolean;
     }
     export interface ComposeOperation {
         name: string;

--- a/frontend/src/views/container/compose/index.vue
+++ b/frontend/src/views/container/compose/index.vue
@@ -334,6 +334,7 @@
                                 </el-form-item>
                                 <span class="envTitle">{{ $t('container.env') }}</span>
                                 <el-input placeholder="key=value" type="textarea" :rows="3" v-model="form.env" />
+                                <span class="envTitle">{{ $t('commons.button.set') }}</span>
                                 <el-form-item>
                                     <el-checkbox v-model="form.pullImage" :label="$t('app.pullImage')" />
                                     <span class="input-help">{{ $t('app.pullImageHelper') }}</span>

--- a/frontend/src/views/container/compose/index.vue
+++ b/frontend/src/views/container/compose/index.vue
@@ -334,6 +334,10 @@
                                 </el-form-item>
                                 <span class="envTitle">{{ $t('container.env') }}</span>
                                 <el-input placeholder="key=value" type="textarea" :rows="3" v-model="form.env" />
+                                <el-form-item>
+                                    <el-checkbox v-model="form.pullImage" :label="$t('app.pullImage')" />
+                                    <span class="input-help">{{ $t('app.pullImageHelper') }}</span>
+                                </el-form-item>
                             </el-form>
 
                             <el-button type="primary" class="mt-2" @click="onSubmit(formRef)">
@@ -426,6 +430,7 @@ const form = reactive({
     file: '',
     template: null as number,
     env: '',
+    pullImage: true,
 });
 const rules = reactive({
     name: [Rules.requiredInput, Rules.composeName],
@@ -555,6 +560,7 @@ const onOpenDialog = async () => {
     form.file = '';
     form.template = null;
     form.env = '';
+    form.pullImage = true;
     loadPath();
     loadTemplates();
 };


### PR DESCRIPTION
#### What this PR does / why we need it?
https://github.com/1Panel-dev/1Panel/issues/11658

#### Summary of your change
开关关闭时 uptask 会直接绕过 pull 过程 直接docker compose up
<img width="866" height="377" alt="image" src="https://github.com/user-attachments/assets/6ef0baea-82c7-417c-92b5-a2e47be211c6" />
<img width="1136" height="673" alt="image" src="https://github.com/user-attachments/assets/328c47fd-ea8b-4afd-b04d-9002e29becce" />

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.