### PR TITLE
fix: ensure local connection is properly closed in CheckLocalConn method

### DIFF
--- a/agent/app/api/v2/setting.go
+++ b/agent/app/api/v2/setting.go
@@ -80,7 +80,10 @@ func (b *BaseApi) LoadLocalConn(c *gin.Context) {
 }
 
 func (b *BaseApi) CheckLocalConn(c *gin.Context) {
-	_, err := loadLocalConn()
+	client, err := loadLocalConn()
+	if err == nil && client != nil {
+		client.Close()
+	}
 	helper.SuccessWithData(c, err == nil)
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it?
https://github.com/1Panel-dev/1Panel/issues/11409

本地稳定复现，不是ws ssh的问题，而是这个不起眼的函数的问题

#### Summary of your change
修复 checkconnection 检查链接后，不对建立链接做关闭的问题
<img width="651" height="384" alt="image" src="https://github.com/user-attachments/assets/4a3bc18d-6d4e-455f-9191-cf3fcda3e805" />
这个函数会创建一个 ssh 链接，返回一个实例

<img width="791" height="156" alt="image" src="https://github.com/user-attachments/assets/96cf522c-ea6c-438c-bf75-4c04a459d351" />
这里用_ 忽略了返回，但是依然存在建立的链接，没有调用close方法去关闭 FD，导致 fd 泄露。

@ssongliu 