### PR TITLE
fix: enhance app icon retrieval logic in home view

### DIFF
--- a/frontend/src/views/home/app/index.vue
+++ b/frontend/src/views/home/app/index.vue
@@ -27,7 +27,7 @@
                     <div class="h-app-card" v-for="(app, index) in apps" :key="index">
                         <el-row :gutter="5">
                             <el-col :span="5">
-                                <el-avatar shape="square" :size="55" :src="'data:image/png;base64,' + app.icon" />
+                                <el-avatar shape="square" :size="55" :src="getAppIconSrc(app)" />
                             </el-col>
                             <el-col :span="16">
                                 <div class="h-app-content" v-if="!app.currentRow">
@@ -179,7 +179,7 @@
 </template>
 
 <script lang="ts" setup>
-import { installedOp } from '@/api/modules/app';
+import { getAppIconUrl, installedOp } from '@/api/modules/app';
 import { getAgentSettingByKey } from '@/api/modules/setting';
 import { changeLauncherStatus, loadAppLauncher, loadAppLauncherOption } from '@/api/modules/dashboard';
 import i18n from '@/lang';
@@ -289,6 +289,14 @@ const onOperate = async (operation: string, row: any) => {
 const loadOption = async () => {
     const res = await loadAppLauncherOption(filter.value || '');
     options.value = res.data || [];
+};
+
+const getAppIconSrc = (app: any) => {
+    const icon = app?.icon || '';
+    if (icon.startsWith('app_') || icon === '') {
+        return getAppIconUrl(app.key);
+    }
+    return `data:image/png;base64,${icon}`;
 };
 
 defineExpose({


### PR DESCRIPTION
- Updated app icon handling to use a dedicated function for improved clarity and maintainability.
- Introduced a new method, getAppIconSrc, to manage icon source retrieval based on app properties.
- Ensured proper handling of base64 and URL-based icons for better performance and consistency.

#### What this PR does / why we need it?
修复新版图标存储逻辑情况下，首页无法加载 icon 的问题

#### Summary of your change
前端自动判断b64 还是 新格式。兼容原版和新存储方案
<img width="810" height="649" alt="image" src="https://github.com/user-attachments/assets/a7ab8728-9d74-441d-b43a-a30a0a88597f" />


