### PR TITLE
feat: add keepdeps.go to preserve mod clean in opensource version

### DIFF
--- a/core/deps/keepdeps.go
+++ b/core/deps/keepdeps.go
@@ -1,0 +1,9 @@
+//go:build !xpack
+
+package deps
+
+// Keep xpack deps from being pruned by go mod tidy
+import (
+	_ "github.com/patrickmn/go-cache"
+	_ "github.com/pkg/sftp"
+)

--- a/core/global/keepdeps.go
+++ b/core/global/keepdeps.go
@@ -1,7 +1,0 @@
-package global
-
-// Keep xpack deps from being pruned by go mod tidy in OSS builds.
-import (
-	_ "github.com/patrickmn/go-cache"
-	_ "github.com/pkg/sftp"
-)

--- a/core/global/keepdeps.go
+++ b/core/global/keepdeps.go
@@ -1,0 +1,7 @@
+package global
+
+// Keep xpack deps from being pruned by go mod tidy in OSS builds.
+import (
+	_ "github.com/patrickmn/go-cache"
+	_ "github.com/pkg/sftp"
+)


### PR DESCRIPTION
#### What this PR does / why we need it?
xpack 专业版应该是用了两个额外的依赖，开源版本因为没这连个依赖，所以go mod tidy会移除，导致其他版本ci编译失败。
添加占位文件避免其他贡献者 tidy 误删除

此 pr 比较 hack，需要讨论是否需要这么做