### PR TITLE
fix: update browser cache handling in website proxy service

### DIFF
--- a/agent/app/service/website_proxy.go
+++ b/agent/app/service/website_proxy.go
@@ -119,8 +119,10 @@ func (w WebsiteService) OperateProxy(req request.WebsiteProxyConfig) (err error)
 		location.RemoveServerCache(fmt.Sprintf("proxy_cache_zone_of_%s", website.Alias))
 	}
 	// Browser Cache Settings
-	if req.CacheTime != 0 {
+	if req.CacheTime > 0 {
 		location.AddBrowserCache(req.CacheTime, req.CacheUnit)
+	} else if req.CacheTime < 0 {
+		location.AddBroswerNoCache()
 	} else {
 		location.RemoveBrowserCache()
 	}

--- a/agent/app/service/website_proxy.go
+++ b/agent/app/service/website_proxy.go
@@ -4,6 +4,10 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"path"
+	"strconv"
+	"strings"
+
 	"github.com/1Panel-dev/1Panel/agent/app/dto"
 	"github.com/1Panel-dev/1Panel/agent/app/dto/request"
 	"github.com/1Panel-dev/1Panel/agent/app/dto/response"
@@ -17,9 +21,6 @@ import (
 	"github.com/1Panel-dev/1Panel/agent/utils/nginx/components"
 	"github.com/1Panel-dev/1Panel/agent/utils/nginx/parser"
 	"github.com/1Panel-dev/1Panel/agent/utils/re"
-	"path"
-	"strconv"
-	"strings"
 )
 
 func (w WebsiteService) OperateProxy(req request.WebsiteProxyConfig) (err error) {
@@ -119,6 +120,9 @@ func (w WebsiteService) OperateProxy(req request.WebsiteProxyConfig) (err error)
 		location.RemoveServerCache(fmt.Sprintf("proxy_cache_zone_of_%s", website.Alias))
 	}
 	// Browser Cache Settings
+	// cacheTime > 0: enable expires;
+	// cacheTime == 0: use upstream cache-control, remove self-set;
+	// cacheTime < 0: force no-cache
 	if req.CacheTime > 0 {
 		location.AddBrowserCache(req.CacheTime, req.CacheUnit)
 	} else if req.CacheTime < 0 {

--- a/frontend/src/api/interface/website.ts
+++ b/frontend/src/api/interface/website.ts
@@ -445,7 +445,7 @@ export namespace Website {
         allowHeaders: string;
         allowCredentials: boolean;
         preflight: boolean;
-        browserCache?: boolean;
+        browserCache?: 'enable' | 'disable' | 'noModify';
     }
 
     export interface ProxReplace {


### PR DESCRIPTION
- Adjusted cache time condition to allow for negative values, introducing a no-cache option.
- Updated TypeScript interface to specify browser cache options as 'enable', 'disable', or 'noModify' for better clarity.

#### What this PR does / why we need it?
修复某个pr导致的浏览器缓存参数不符合原有预期情况
浏览器缓存选择禁用会导致cache -1
<img width="665" height="227" alt="image" src="https://github.com/user-attachments/assets/91240bf9-ba7b-4aca-9099-0b2ff3993225" />

#### Summary of your change
修复 浏览器缓存 不修改缓存头/禁用缓存（重写no-cache)/ 写入缓存的三个模式

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.