### PR TITLE
feat: Implement caching for settings retrieval and update logic

### DIFF
--- a/core/app/repo/setting.go
+++ b/core/app/repo/setting.go
@@ -14,9 +14,8 @@ import (
 type SettingRepo struct{}
 
 var (
-	settingCache       = cache.New(5*time.Minute, 10*time.Minute)
-	settingDefaultTTL  = 5 * time.Minute
-	settingCriticalTTL = 5 * time.Second
+	settingCache = cache.New(5*time.Minute, 10*time.Minute)
+	settingTTL   = 5 * time.Minute
 )
 
 type ISettingRepo interface {
@@ -31,14 +30,6 @@ type ISettingRepo interface {
 
 func NewISettingRepo() ISettingRepo {
 	return &SettingRepo{}
-}
-
-func loadSettingTTL(key string) time.Duration {
-	switch key {
-	case "AllowIPs", "BindDomain", "SSL":
-		return settingCriticalTTL
-	}
-	return settingDefaultTTL
 }
 
 func (u *SettingRepo) List(opts ...global.DBOption) ([]model.Setting, error) {
@@ -59,7 +50,7 @@ func (u *SettingRepo) Create(key, value string) error {
 	if err := global.DB.Create(setting).Error; err != nil {
 		return err
 	}
-	settingCache.Set(key, value, loadSettingTTL(key))
+	settingCache.Set(key, value, settingTTL)
 	return nil
 }
 
@@ -72,7 +63,7 @@ func (u *SettingRepo) Get(opts ...global.DBOption) (model.Setting, error) {
 
 	err := db.First(&settings).Error
 	if err == nil && settings.Key != "" {
-		settingCache.Set(settings.Key, settings.Value, loadSettingTTL(settings.Key))
+		settingCache.Set(settings.Key, settings.Value, settingTTL)
 	}
 	return settings, err
 }
@@ -86,7 +77,7 @@ func (u *SettingRepo) GetValueByKey(key string) (string, error) {
 	if err := global.DB.Model(&model.Setting{}).Where("key = ?", key).First(&setting).Error; err != nil {
 		return "", err
 	}
-	settingCache.Set(key, setting.Value, loadSettingTTL(key))
+	settingCache.Set(key, setting.Value, settingTTL)
 	return setting.Value, nil
 }
 
@@ -94,7 +85,7 @@ func (u *SettingRepo) Update(key, value string) error {
 	if err := global.DB.Model(&model.Setting{}).Where("key = ?", key).Updates(map[string]interface{}{"value": value}).Error; err != nil {
 		return err
 	}
-	settingCache.Set(key, value, loadSettingTTL(key))
+	settingCache.Set(key, value, settingTTL)
 	return nil
 }
 
@@ -106,7 +97,7 @@ func (u *SettingRepo) UpdateOrCreate(key, value string) error {
 			if err := global.DB.Create(&model.Setting{Key: key, Value: value}).Error; err != nil {
 				return err
 			}
-			settingCache.Set(key, value, loadSettingTTL(key))
+			settingCache.Set(key, value, settingTTL)
 			return nil
 		}
 		return result.Error
@@ -114,7 +105,7 @@ func (u *SettingRepo) UpdateOrCreate(key, value string) error {
 	if err := global.DB.Model(&setting).UpdateColumn("value", value).Error; err != nil {
 		return err
 	}
-	settingCache.Set(key, value, loadSettingTTL(key))
+	settingCache.Set(key, value, settingTTL)
 	return nil
 }
 
@@ -125,6 +116,6 @@ func (u *SettingRepo) DefaultMenu() error {
 		Update("value", menus).Error; err != nil {
 		return err
 	}
-	settingCache.Set("HideMenu", menus, settingDefaultTTL)
+	settingCache.Set("HideMenu", menus, settingTTL)
 	return nil
 }

--- a/core/app/repo/setting.go
+++ b/core/app/repo/setting.go
@@ -14,8 +14,9 @@ import (
 type SettingRepo struct{}
 
 var (
-	settingCache    = cache.New(5*time.Minute, 10*time.Minute)
-	settingCacheTTL = 5 * time.Minute
+	settingCache       = cache.New(5*time.Minute, 10*time.Minute)
+	settingDefaultTTL  = 5 * time.Minute
+	settingCriticalTTL = 5 * time.Second
 )
 
 type ISettingRepo interface {
@@ -30,6 +31,14 @@ type ISettingRepo interface {
 
 func NewISettingRepo() ISettingRepo {
 	return &SettingRepo{}
+}
+
+func loadSettingTTL(key string) time.Duration {
+	switch key {
+	case "AllowIPs", "BindDomain", "SSL":
+		return settingCriticalTTL
+	}
+	return settingDefaultTTL
 }
 
 func (u *SettingRepo) List(opts ...global.DBOption) ([]model.Setting, error) {
@@ -50,7 +59,7 @@ func (u *SettingRepo) Create(key, value string) error {
 	if err := global.DB.Create(setting).Error; err != nil {
 		return err
 	}
-	settingCache.Set(key, value, settingCacheTTL)
+	settingCache.Set(key, value, loadSettingTTL(key))
 	return nil
 }
 
@@ -63,7 +72,7 @@ func (u *SettingRepo) Get(opts ...global.DBOption) (model.Setting, error) {
 
 	err := db.First(&settings).Error
 	if err == nil && settings.Key != "" {
-		settingCache.Set(settings.Key, settings.Value, settingCacheTTL)
+		settingCache.Set(settings.Key, settings.Value, loadSettingTTL(settings.Key))
 	}
 	return settings, err
 }
@@ -77,7 +86,7 @@ func (u *SettingRepo) GetValueByKey(key string) (string, error) {
 	if err := global.DB.Model(&model.Setting{}).Where("key = ?", key).First(&setting).Error; err != nil {
 		return "", err
 	}
-	settingCache.Set(key, setting.Value, settingCacheTTL)
+	settingCache.Set(key, setting.Value, loadSettingTTL(key))
 	return setting.Value, nil
 }
 
@@ -85,7 +94,7 @@ func (u *SettingRepo) Update(key, value string) error {
 	if err := global.DB.Model(&model.Setting{}).Where("key = ?", key).Updates(map[string]interface{}{"value": value}).Error; err != nil {
 		return err
 	}
-	settingCache.Set(key, value, settingCacheTTL)
+	settingCache.Set(key, value, loadSettingTTL(key))
 	return nil
 }
 
@@ -97,7 +106,7 @@ func (u *SettingRepo) UpdateOrCreate(key, value string) error {
 			if err := global.DB.Create(&model.Setting{Key: key, Value: value}).Error; err != nil {
 				return err
 			}
-			settingCache.Set(key, value, settingCacheTTL)
+			settingCache.Set(key, value, loadSettingTTL(key))
 			return nil
 		}
 		return result.Error
@@ -105,7 +114,7 @@ func (u *SettingRepo) UpdateOrCreate(key, value string) error {
 	if err := global.DB.Model(&setting).UpdateColumn("value", value).Error; err != nil {
 		return err
 	}
-	settingCache.Set(key, value, settingCacheTTL)
+	settingCache.Set(key, value, loadSettingTTL(key))
 	return nil
 }
 
@@ -116,6 +125,6 @@ func (u *SettingRepo) DefaultMenu() error {
 		Update("value", menus).Error; err != nil {
 		return err
 	}
-	settingCache.Set("HideMenu", menus, settingCacheTTL)
+	settingCache.Set("HideMenu", menus, settingDefaultTTL)
 	return nil
 }

--- a/core/app/repo/setting.go
+++ b/core/app/repo/setting.go
@@ -2,13 +2,21 @@ package repo
 
 import (
 	"errors"
+	"time"
+
 	"github.com/1Panel-dev/1Panel/core/app/model"
 	"github.com/1Panel-dev/1Panel/core/global"
 	"github.com/1Panel-dev/1Panel/core/init/migration/helper"
+	"github.com/patrickmn/go-cache"
 	"gorm.io/gorm"
 )
 
 type SettingRepo struct{}
+
+var (
+	settingCache    = cache.New(5*time.Minute, 10*time.Minute)
+	settingCacheTTL = 5 * time.Minute
+)
 
 type ISettingRepo interface {
 	List(opts ...global.DBOption) ([]model.Setting, error)
@@ -39,7 +47,11 @@ func (u *SettingRepo) Create(key, value string) error {
 		Key:   key,
 		Value: value,
 	}
-	return global.DB.Create(setting).Error
+	if err := global.DB.Create(setting).Error; err != nil {
+		return err
+	}
+	settingCache.Set(key, value, settingCacheTTL)
+	return nil
 }
 
 func (u *SettingRepo) Get(opts ...global.DBOption) (model.Setting, error) {
@@ -48,20 +60,33 @@ func (u *SettingRepo) Get(opts ...global.DBOption) (model.Setting, error) {
 	for _, opt := range opts {
 		db = opt(db)
 	}
+
 	err := db.First(&settings).Error
+	if err == nil && settings.Key != "" {
+		settingCache.Set(settings.Key, settings.Value, settingCacheTTL)
+	}
 	return settings, err
 }
 
 func (u *SettingRepo) GetValueByKey(key string) (string, error) {
+	if val, found := settingCache.Get(key); found {
+		return val.(string), nil
+	}
+
 	var setting model.Setting
 	if err := global.DB.Model(&model.Setting{}).Where("key = ?", key).First(&setting).Error; err != nil {
 		return "", err
 	}
+	settingCache.Set(key, setting.Value, settingCacheTTL)
 	return setting.Value, nil
 }
 
 func (u *SettingRepo) Update(key, value string) error {
-	return global.DB.Model(&model.Setting{}).Where("key = ?", key).Updates(map[string]interface{}{"value": value}).Error
+	if err := global.DB.Model(&model.Setting{}).Where("key = ?", key).Updates(map[string]interface{}{"value": value}).Error; err != nil {
+		return err
+	}
+	settingCache.Set(key, value, settingCacheTTL)
+	return nil
 }
 
 func (u *SettingRepo) UpdateOrCreate(key, value string) error {
@@ -69,15 +94,28 @@ func (u *SettingRepo) UpdateOrCreate(key, value string) error {
 	result := global.DB.Where("key = ?", key).First(&setting)
 	if result.Error != nil {
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-			return global.DB.Create(&model.Setting{Key: key, Value: value}).Error
+			if err := global.DB.Create(&model.Setting{Key: key, Value: value}).Error; err != nil {
+				return err
+			}
+			settingCache.Set(key, value, settingCacheTTL)
+			return nil
 		}
 		return result.Error
 	}
-	return global.DB.Model(&setting).UpdateColumn("value", value).Error
+	if err := global.DB.Model(&setting).UpdateColumn("value", value).Error; err != nil {
+		return err
+	}
+	settingCache.Set(key, value, settingCacheTTL)
+	return nil
 }
 
 func (u *SettingRepo) DefaultMenu() error {
-	return global.DB.Model(&model.Setting{}).
+	menus := helper.LoadMenus()
+	if err := global.DB.Model(&model.Setting{}).
 		Where("key = ?", "HideMenu").
-		Update("value", helper.LoadMenus()).Error
+		Update("value", menus).Error; err != nil {
+		return err
+	}
+	settingCache.Set("HideMenu", menus, settingCacheTTL)
+	return nil
 }

--- a/core/cmd/server/cmd/reset.go
+++ b/core/cmd/server/cmd/reset.go
@@ -2,9 +2,11 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/1Panel-dev/1Panel/core/constant"
 	"github.com/1Panel-dev/1Panel/core/i18n"
+	cmdUtils "github.com/1Panel-dev/1Panel/core/utils/cmd"
 	"github.com/1Panel-dev/1Panel/core/utils/passkey"
 	"github.com/spf13/cobra"
 )
@@ -62,7 +64,10 @@ var resetSSLCmd = &cobra.Command{
 			return err
 		}
 
-		return setSettingByKey(db, "SSL", constant.StatusDisable)
+		if err := setSettingByKey(db, "SSL", constant.StatusDisable); err != nil {
+			return err
+		}
+		return restartCoreAfterReset()
 	},
 }
 var resetEntranceCmd = &cobra.Command{
@@ -94,7 +99,10 @@ var resetBindIpsCmd = &cobra.Command{
 			return err
 		}
 
-		return setSettingByKey(db, "AllowIPs", "")
+		if err := setSettingByKey(db, "AllowIPs", ""); err != nil {
+			return err
+		}
+		return restartCoreAfterReset()
 	},
 }
 var resetDomainCmd = &cobra.Command{
@@ -110,7 +118,10 @@ var resetDomainCmd = &cobra.Command{
 			return err
 		}
 
-		return setSettingByKey(db, "BindDomain", "")
+		if err := setSettingByKey(db, "BindDomain", ""); err != nil {
+			return err
+		}
+		return restartCoreAfterReset()
 	},
 }
 
@@ -131,6 +142,22 @@ var resetPasskeyCmd = &cobra.Command{
 		}
 		return setSettingByKey(db, passkey.PasskeyCredentialSettingKey, "")
 	},
+}
+
+func restartCoreAfterReset() error {
+	stdout, err := cmdUtils.RunDefaultWithStdoutBashC("1pctl restart core")
+	if len(stdout) != 0 {
+		fmt.Print(stdout)
+	}
+	if err == nil {
+		return nil
+	}
+
+	stdout = strings.TrimSpace(stdout)
+	if len(stdout) != 0 {
+		return fmt.Errorf("reset succeeded but restart core failed: %s", stdout)
+	}
+	return fmt.Errorf("reset succeeded but restart core failed: %v", err)
 }
 
 func loadResetHelper() {

--- a/core/init/router/proxy.go
+++ b/core/init/router/proxy.go
@@ -71,16 +71,16 @@ func checkSession(c *gin.Context) bool {
 		return false
 	}
 	settingRepo := repo.NewISettingRepo()
-	setting, err := settingRepo.Get(repo.WithByKey("SessionTimeout"))
+	sessionTimeout, err := settingRepo.GetValueByKey("SessionTimeout")
 	if err != nil {
 		return false
 	}
-	lifeTime, _ := strconv.Atoi(setting.Value)
-	httpsSetting, err := settingRepo.Get(repo.WithByKey("SSL"))
+	lifeTime, _ := strconv.Atoi(sessionTimeout)
+	ssl, err := settingRepo.GetValueByKey("SSL")
 	if err != nil {
 		return false
 	}
-	_ = global.SESSION.Set(c, psession, httpsSetting.Value == constant.StatusEnable, lifeTime)
+	_ = global.SESSION.Set(c, psession, ssl == constant.StatusEnable, lifeTime)
 	return true
 }
 

--- a/core/middleware/bind_domain.go
+++ b/core/middleware/bind_domain.go
@@ -16,12 +16,12 @@ func BindDomain() gin.HandlerFunc {
 			return
 		}
 		settingRepo := repo.NewISettingRepo()
-		status, err := settingRepo.Get(repo.WithByKey("BindDomain"))
+		bindDomain, err := settingRepo.GetValueByKey("BindDomain")
 		if err != nil {
 			helper.InternalServer(c, err)
 			return
 		}
-		if len(status.Value) == 0 {
+		if len(bindDomain) == 0 {
 			c.Next()
 			return
 		}
@@ -31,7 +31,7 @@ func BindDomain() gin.HandlerFunc {
 			domains = parts[0]
 		}
 
-		if domains != status.Value {
+		if domains != bindDomain {
 			code := LoadErrCode()
 			helper.ErrWithHtml(c, code, "err_domain")
 			return

--- a/core/middleware/helper.go
+++ b/core/middleware/helper.go
@@ -8,12 +8,12 @@ import (
 
 func LoadErrCode() int {
 	settingRepo := repo.NewISettingRepo()
-	codeVal, err := settingRepo.Get(repo.WithByKey("NoAuthSetting"))
+	codeVal, err := settingRepo.GetValueByKey("NoAuthSetting")
 	if err != nil {
 		return 500
 	}
 
-	switch codeVal.Value {
+	switch codeVal {
 	case "400":
 		return http.StatusBadRequest
 	case "401":

--- a/core/middleware/ip_limit.go
+++ b/core/middleware/ip_limit.go
@@ -24,17 +24,17 @@ func WhiteAllow() gin.HandlerFunc {
 		}
 
 		settingRepo := repo.NewISettingRepo()
-		status, err := settingRepo.Get(repo.WithByKey("AllowIPs"))
+		allowIPs, err := settingRepo.GetValueByKey("AllowIPs")
 		if err != nil {
 			helper.InternalServer(c, err)
 			return
 		}
 
-		if len(status.Value) == 0 {
+		if len(allowIPs) == 0 {
 			c.Next()
 			return
 		}
-		for _, ip := range strings.Split(status.Value, ",") {
+		for _, ip := range strings.Split(allowIPs, ",") {
 			if len(ip) == 0 {
 				continue
 			}

--- a/core/middleware/loading.go
+++ b/core/middleware/loading.go
@@ -9,13 +9,13 @@ import (
 func GlobalLoading() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		settingRepo := repo.NewISettingRepo()
-		status, err := settingRepo.Get(repo.WithByKey("SystemStatus"))
+		status, err := settingRepo.GetValueByKey("SystemStatus")
 		if err != nil {
 			helper.InternalServer(c, err)
 			return
 		}
-		if status.Value != "Free" {
-			helper.ErrorWithDetail(c, 407, status.Value, err)
+		if status != "Free" {
+			helper.ErrorWithDetail(c, 407, status, err)
 			return
 		}
 		c.Next()

--- a/core/middleware/password_expired.go
+++ b/core/middleware/password_expired.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/1Panel-dev/1Panel/core/app/api/v2/helper"
@@ -11,6 +12,11 @@ import (
 	"github.com/1Panel-dev/1Panel/core/constant"
 	"github.com/1Panel-dev/1Panel/core/utils/common"
 	"github.com/gin-gonic/gin"
+)
+
+var (
+	expiredLoc     *time.Location
+	expiredLocOnce sync.Once
 )
 
 func PasswordExpired() gin.HandlerFunc {
@@ -22,24 +28,23 @@ func PasswordExpired() gin.HandlerFunc {
 			return
 		}
 		settingRepo := repo.NewISettingRepo()
-		setting, err := settingRepo.Get(repo.WithByKey("ExpirationDays"))
+		expirationDays, err := settingRepo.GetValueByKey("ExpirationDays")
 		if err != nil {
 			helper.ErrorWithDetail(c, http.StatusInternalServerError, "ErrPasswordExpired", err)
 			return
 		}
-		expiredDays, _ := strconv.Atoi(setting.Value)
+		expiredDays, _ := strconv.Atoi(expirationDays)
 		if expiredDays == 0 {
 			c.Next()
 			return
 		}
 
-		extime, err := settingRepo.Get(repo.WithByKey("ExpirationTime"))
+		expirationTime, err := settingRepo.GetValueByKey("ExpirationTime")
 		if err != nil {
 			helper.ErrorWithDetail(c, http.StatusInternalServerError, "ErrPasswordExpired", err)
 			return
 		}
-		loc, _ := time.LoadLocation(common.LoadTimeZoneByCmd())
-		expiredTime, err := time.ParseInLocation(constant.DateTimeLayout, extime.Value, loc)
+		expiredTime, err := time.ParseInLocation(constant.DateTimeLayout, expirationTime, loadExpiredLocation())
 		if err != nil {
 			helper.ErrorWithDetail(c, 313, "ErrPasswordExpired", err)
 			return
@@ -50,4 +55,19 @@ func PasswordExpired() gin.HandlerFunc {
 		}
 		c.Next()
 	}
+}
+
+func loadExpiredLocation() *time.Location {
+	expiredLocOnce.Do(func() {
+		loc, err := time.LoadLocation(common.LoadTimeZoneByCmd())
+		if err != nil {
+			expiredLoc = time.Local
+			return
+		}
+		expiredLoc = loc
+	})
+	if expiredLoc == nil {
+		return time.Local
+	}
+	return expiredLoc
 }

--- a/core/middleware/password_rsa.go
+++ b/core/middleware/password_rsa.go
@@ -10,8 +10,8 @@ func SetPasswordPublicKey() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		cookieKey, _ := c.Cookie("panel_public_key")
 		settingRepo := repo.NewISettingRepo()
-		key, _ := settingRepo.Get(repo.WithByKey("PASSWORD_PUBLIC_KEY"))
-		base64Key := base64.StdEncoding.EncodeToString([]byte(key.Value))
+		key, _ := settingRepo.GetValueByKey("PASSWORD_PUBLIC_KEY")
+		base64Key := base64.StdEncoding.EncodeToString([]byte(key))
 		if base64Key == cookieKey {
 			c.Next()
 			return

--- a/core/middleware/session.go
+++ b/core/middleware/session.go
@@ -24,18 +24,18 @@ func SessionAuth() gin.HandlerFunc {
 			return
 		}
 		settingRepo := repo.NewISettingRepo()
-		setting, err := settingRepo.Get(repo.WithByKey("SessionTimeout"))
+		sessionTimeout, err := settingRepo.GetValueByKey("SessionTimeout")
 		if err != nil {
 			global.LOG.Errorf("create operation record failed, err: %v", err)
 			return
 		}
-		lifeTime, _ := strconv.Atoi(setting.Value)
-		httpsSetting, err := settingRepo.Get(repo.WithByKey("SSL"))
+		lifeTime, _ := strconv.Atoi(sessionTimeout)
+		ssl, err := settingRepo.GetValueByKey("SSL")
 		if err != nil {
 			global.LOG.Errorf("create operation record failed, err: %v", err)
 			return
 		}
-		_ = global.SESSION.Set(c, psession, httpsSetting.Value == constant.StatusEnable, lifeTime)
+		_ = global.SESSION.Set(c, psession, ssl == constant.StatusEnable, lifeTime)
 		c.Next()
 	}
 }


### PR DESCRIPTION
2.0.18 改动已经很多了， 暂时不合这个，等合进 2.0.19

- Introduced a caching mechanism for settings using go-cache to improve performance.
- Updated the Create, Update, and UpdateOrCreate methods to cache values after database operations.
- Modified the Get and GetValueByKey methods to utilize the cache for faster access.
- Adjusted middleware to use the new GetValueByKey method for retrieving settings, enhancing code consistency.

#### What this PR does / why we need it?
中间件需要多次读取 sqlite 里的数据，在 io 差的服务器可能会造成一定负担

#### Summary of your change
给中间件所需参数缓存进 go-cache内存(五分钟缓存，更新会刷新缓存），减少数据库 io 调用

流程图 by AI
```mermaid
graph TB
    Start([HTTP 请求开始]) --> GlobalLoading[GlobalLoading 中间件]
    
    GlobalLoading --> |读取缓存| SystemStatus["🔑 SystemStatus<br/>(系统状态)"]
    SystemStatus --> |Free| SetPasswordPublicKey[SetPasswordPublicKey 中间件]
    SystemStatus --> |非 Free| Error407[返回 407 错误]
    
    SetPasswordPublicKey --> |读取缓存| PasswordPublicKey["🔑 PASSWORD_PUBLIC_KEY<br/>(RSA 公钥)"]
    PasswordPublicKey --> BindDomain[BindDomain 中间件]
    
    BindDomain --> |本地请求| WhiteAllow[WhiteAllow 中间件]
    BindDomain --> |读取缓存| BindDomainKey["🔑 BindDomain<br/>(绑定域名)"]
    BindDomainKey --> |域名匹配| WhiteAllow
    BindDomainKey --> |域名不匹配| LoadErrCode1[LoadErrCode]
    LoadErrCode1 --> |读取缓存| NoAuthSetting1["🔑 NoAuthSetting<br/>(未授权返回码)"]
    NoAuthSetting1 --> ErrorDomain[返回域名错误]
    
    WhiteAllow --> |私有 IP| SessionAuth[SessionAuth 中间件]
    WhiteAllow --> |读取缓存| AllowIPs["🔑 AllowIPs<br/>(IP 白名单)"]
    AllowIPs --> |IP 匹配| SessionAuth
    AllowIPs --> |IP 不匹配| LoadErrCode2[LoadErrCode]
    LoadErrCode2 --> |读取缓存| NoAuthSetting2["🔑 NoAuthSetting<br/>(未授权返回码)"]
    NoAuthSetting2 --> ErrorIP[返回 IP 限制错误]
    
    SessionAuth --> |auth 路径| PasswordExpired[PasswordExpired 中间件]
    SessionAuth --> |读取缓存| SessionTimeout1["🔑 SessionTimeout<br/>(会话超时时间)"]
    SessionAuth --> |读取缓存| SSL1["🔑 SSL<br/>(SSL 状态)"]
    SessionTimeout1 --> PasswordExpired
    SSL1 --> PasswordExpired
    
    PasswordExpired --> |auth 路径| Proxy[Proxy 路由处理]
    PasswordExpired --> |读取缓存| ExpirationDays["🔑 ExpirationDays<br/>(密码过期天数)"]
    PasswordExpired --> |读取缓存| ExpirationTime["🔑 ExpirationTime<br/>(密码过期时间)"]
    ExpirationDays --> |0 天| Proxy
    ExpirationDays --> |非 0 天| CheckTime{检查过期时间}
    ExpirationTime --> CheckTime
    CheckTime --> |未过期| Proxy
    CheckTime --> |已过期| Error313[返回 313 密码过期]
    
    Proxy --> |core 路径| Handler[业务处理器]
    Proxy --> |非本地 agent 路径| ProxyCheckSession[checkSession 验证]
    ProxyCheckSession --> |读取缓存| SessionTimeout2["🔑 SessionTimeout<br/>(会话超时时间)"]
    ProxyCheckSession --> |读取缓存| SSL2["🔑 SSL<br/>(SSL 状态)"]
    SessionTimeout2 --> ProxyAgent[转发到 Agent]
    SSL2 --> ProxyAgent
    
    Handler --> End([请求处理完成])
    ProxyAgent --> End
    
    style SystemStatus fill:#e1f5ff,stroke:#0066cc,stroke-width:2px,color:#000000
    style PasswordPublicKey fill:#e1f5ff,stroke:#0066cc,stroke-width:2px,color:#000000
    style BindDomainKey fill:#e1f5ff,stroke:#0066cc,stroke-width:2px,color:#000000
    style NoAuthSetting1 fill:#e1f5ff,stroke:#0066cc,stroke-width:2px,color:#000000
    style AllowIPs fill:#e1f5ff,stroke:#0066cc,stroke-width:2px,color:#000000
    style NoAuthSetting2 fill:#e1f5ff,stroke:#0066cc,stroke-width:2px,color:#000000
    style SessionTimeout1 fill:#e1f5ff,stroke:#0066cc,stroke-width:2px,color:#000000
    style SSL1 fill:#e1f5ff,stroke:#0066cc,stroke-width:2px,color:#000000
    style ExpirationDays fill:#e1f5ff,stroke:#0066cc,stroke-width:2px,color:#000000
    style ExpirationTime fill:#e1f5ff,stroke:#0066cc,stroke-width:2px,color:#000000
    style SessionTimeout2 fill:#e1f5ff,stroke:#0066cc,stroke-width:2px,color:#000000
    style SSL2 fill:#e1f5ff,stroke:#0066cc,stroke-width:2px,color:#000000
    
    style GlobalLoading fill:#fff4e6,stroke:#ff9800,stroke-width:2px,color:#000000
    style SetPasswordPublicKey fill:#fff4e6,stroke:#ff9800,stroke-width:2px,color:#000000
    style BindDomain fill:#fff4e6,stroke:#ff9800,stroke-width:2px,color:#000000
    style WhiteAllow fill:#fff4e6,stroke:#ff9800,stroke-width:2px,color:#000000
    style SessionAuth fill:#fff4e6,stroke:#ff9800,stroke-width:2px,color:#000000
    style PasswordExpired fill:#fff4e6,stroke:#ff9800,stroke-width:2px,color:#000000
    style Proxy fill:#fff4e6,stroke:#ff9800,stroke-width:2px,color:#000000
```

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.