### PR TITLE
fix: 修复两个 SQL 注入漏洞

### DIFF
--- a/agent/app/api/v2/website_ssl.go
+++ b/agent/app/api/v2/website_ssl.go
@@ -26,7 +26,7 @@ import (
 // @Router /websites/ssl/search [post]
 func (b *BaseApi) PageWebsiteSSL(c *gin.Context) {
 	var req request.WebsiteSSLSearch
-	if err := helper.CheckBind(&req, c); err != nil {
+	if err := helper.CheckBindAndValidate(&req, c); err != nil {
 		return
 	}
 	if !reflect.DeepEqual(req.PageInfo, dto.PageInfo{}) {

--- a/agent/app/repo/common.go
+++ b/agent/app/repo/common.go
@@ -3,6 +3,7 @@ package repo
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/1Panel-dev/1Panel/agent/constant"
@@ -151,8 +152,13 @@ func WithByCreatedAt(startTime, endTime time.Time) DBOption {
 	}
 }
 
+var validColumnName = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
 func WithOrderBy(orderStr string) DBOption {
 	if orderStr == "createdAt" {
+		orderStr = "created_at"
+	}
+	if !validColumnName.MatchString(orderStr) {
 		orderStr = "created_at"
 	}
 	return func(g *gorm.DB) *gorm.DB {
@@ -161,6 +167,9 @@ func WithOrderBy(orderStr string) DBOption {
 }
 func WithOrderRuleBy(orderBy, order string) DBOption {
 	if orderBy == "createdAt" {
+		orderBy = "created_at"
+	}
+	if !validColumnName.MatchString(orderBy) {
 		orderBy = "created_at"
 	}
 	switch order {


### PR DESCRIPTION
#### What this PR does / why we need it?

[monkeycode](https://monkeycode-ai.com/) 发现了 1panel 的两个 SQL 注入漏洞，修复之。

`WithOrderBy` 和 `WithOrderRuleBy` 函数将用户传入的 `orderBy` 参数通过 `fmt.Sprintf` 直接拼接到 SQL `ORDER BY` 子句中，未做任何合法性校验，攻击者可以构造恶意 `orderBy` 值实现 SQL 注入。受影响的接口包括但不限于：

- `POST /api/v2/backups/record/size` -- `SearchForSize.OrderBy` 无 validate 标签，可传入任意值
- `POST /api/v2/websites/ssl/search` -- `WebsiteSSLSearch.OrderBy` 虽有 `oneof=expire_date` 校验标签，但 handler 使用 `CheckBind` 而非 `CheckBindAndValidate`，导致校验未生效

#### Summary of your change

1. **`agent/app/repo/common.go`**: 在 `WithOrderBy` 和 `WithOrderRuleBy` 中新增正则校验 `^[a-zA-Z_][a-zA-Z0-9_]*$`，确保 `orderBy` 只包含合法的列名字符（字母、数字、下划线）。不合法时回退到默认值 `created_at`。此修复覆盖了所有调用这两个函数的模块（cronjob、website、database、snapshot、clam 等）。

2. **`agent/app/api/v2/website_ssl.go`**: 将 `PageWebsiteSSL` handler 中的 `helper.CheckBind` 改为 `helper.CheckBindAndValidate`，使 `WebsiteSSLSearch` 结构体上的 `validate:"required,oneof=expire_date"` 标签生效，从 DTO 层限制 `orderBy` 的合法值。

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.