### PR TITLE
修复 8 个命令注入漏洞

### DIFF
--- a/agent/app/service/disk.go
+++ b/agent/app/service/disk.go
@@ -50,6 +50,9 @@ func (s *DiskService) GetCompleteDiskInfo() (*response.CompleteDiskInfo, error) 
 }
 
 func (s *DiskService) PartitionDisk(req request.DiskPartitionRequest) (string, error) {
+	if cmd.CheckIllegal(req.Device, req.Filesystem, req.MountPoint, req.Label) {
+		return "", buserr.New("ErrCmdIllegal")
+	}
 	if !strings.HasPrefix("/dev", req.Device) {
 		req.Device = "/dev/" + req.Device
 	}
@@ -104,6 +107,9 @@ func (s *DiskService) PartitionDisk(req request.DiskPartitionRequest) (string, e
 }
 
 func (s *DiskService) MountDisk(req request.DiskMountRequest) error {
+	if cmd.CheckIllegal(req.Device, req.MountPoint, req.Filesystem) {
+		return buserr.New("ErrCmdIllegal")
+	}
 	if !deviceExists(req.Device) {
 		return buserr.WithName("DeviceNotFound", req.Device)
 	}
@@ -144,6 +150,9 @@ func (s *DiskService) MountDisk(req request.DiskMountRequest) error {
 }
 
 func (s *DiskService) UnmountDisk(req request.DiskUnmountRequest) error {
+	if cmd.CheckIllegal(req.MountPoint) {
+		return buserr.New("ErrCmdIllegal")
+	}
 	if !isPointMounted(req.MountPoint) {
 		return buserr.New("MountDiskErr")
 	}

--- a/agent/app/service/ssh.go
+++ b/agent/app/service/ssh.go
@@ -465,6 +465,9 @@ func (u *SSHService) LoadLog(ctx *gin.Context, req dto.SearchSSHLog) (int64, []d
 
 	command := ""
 	if len(req.Info) != 0 {
+		if cmd.CheckIllegal(req.Info) {
+			return 0, data, buserr.New("ErrCmdIllegal")
+		}
 		command = fmt.Sprintf(" | grep '%s'", req.Info)
 	}
 

--- a/agent/app/service/website.go
+++ b/agent/app/service/website.go
@@ -2297,6 +2297,9 @@ func (w WebsiteService) OperateCrossSiteAccess(req request.CrossSiteAccessOp) er
 }
 
 func (w WebsiteService) ExecComposer(req request.ExecComposerReq) error {
+	if cmd.CheckIllegal(req.User, req.Mirror, req.Command, req.ExtCommand) {
+		return buserr.New("ErrCmdIllegal")
+	}
 	website, err := websiteRepo.GetFirst(repo.WithByID(req.WebsiteID))
 	if err != nil {
 		return err

--- a/agent/utils/firewall/client/firewalld.go
+++ b/agent/utils/firewall/client/firewalld.go
@@ -196,6 +196,9 @@ func (f *Firewall) RichRules(rule FireInfo, operation string) error {
 }
 
 func (f *Firewall) PortForward(info Forward, operation string) error {
+	if cmd.CheckIllegal(operation, info.Port, info.Protocol, info.TargetIP, info.TargetPort) {
+		return buserr.New("ErrCmdIllegal")
+	}
 	ruleStr := fmt.Sprintf("firewall-cmd --zone=public --%s-forward-port=port=%s:proto=%s:toport=%s --permanent", operation, info.Port, info.Protocol, info.TargetPort)
 	if info.TargetIP != "" && info.TargetIP != "127.0.0.1" && info.TargetIP != "localhost" {
 		ruleStr = fmt.Sprintf("firewall-cmd --zone=public --%s-forward-port=port=%s:proto=%s:toaddr=%s:toport=%s --permanent", operation, info.Port, info.Protocol, info.TargetIP, info.TargetPort)

--- a/agent/utils/firewall/client/iptables/filter.go
+++ b/agent/utils/firewall/client/iptables/filter.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/1Panel-dev/1Panel/agent/buserr"
 	"github.com/1Panel-dev/1Panel/agent/global"
 	"github.com/1Panel-dev/1Panel/agent/utils/cmd"
 )
@@ -70,6 +71,9 @@ func DeleteFilterRule(chain string, policy FilterRules) error {
 
 func ReadFilterRulesByChain(chain string) ([]FilterRules, error) {
 	var rules []FilterRules
+	if cmd.CheckIllegal(chain) {
+		return rules, buserr.New("ErrCmdIllegal")
+	}
 	cmdMgr := cmd.NewCommandMgr(cmd.WithIgnoreExist1(), cmd.WithTimeout(20*time.Second))
 	stdout, err := cmdMgr.RunWithStdoutBashCf("%s iptables -w -t %s -nL %s", cmd.SudoHandleCmd(), FilterTab, chain)
 	if err != nil {
@@ -100,6 +104,9 @@ func ReadFilterRulesByChain(chain string) ([]FilterRules, error) {
 }
 
 func LoadDefaultStrategy(chain string) (string, error) {
+	if cmd.CheckIllegal(chain) {
+		return "", buserr.New("ErrCmdIllegal")
+	}
 	cmdMgr := cmd.NewCommandMgr(cmd.WithIgnoreExist1(), cmd.WithTimeout(20*time.Second))
 	stdout, err := cmdMgr.RunWithStdoutBashCf("%s iptables -w -t %s -L %s", cmd.SudoHandleCmd(), FilterTab, chain)
 	if err != nil {

--- a/agent/utils/mysql/client/remote.go
+++ b/agent/utils/mysql/client/remote.go
@@ -17,6 +17,7 @@ import (
 	"github.com/1Panel-dev/1Panel/agent/buserr"
 	"github.com/1Panel-dev/1Panel/agent/constant"
 	"github.com/1Panel-dev/1Panel/agent/global"
+	"github.com/1Panel-dev/1Panel/agent/utils/cmd"
 	"github.com/1Panel-dev/1Panel/agent/utils/common"
 	"github.com/1Panel-dev/1Panel/agent/utils/files"
 	"github.com/docker/docker/api/types/image"
@@ -234,6 +235,9 @@ func (r *Remote) ChangeAccess(info AccessChangeInfo) error {
 }
 
 func (r *Remote) Backup(info BackupInfo) error {
+	if cmd.CheckIllegal(r.Password, r.Address, r.User, info.Name, info.Format) {
+		return buserr.New("ErrCmdIllegal")
+	}
 	fileOp := files.NewFileOp()
 	if !fileOp.Stat(info.TargetDir) {
 		if err := os.MkdirAll(info.TargetDir, os.ModePerm); err != nil {
@@ -285,6 +289,9 @@ func (r *Remote) Backup(info BackupInfo) error {
 }
 
 func (r *Remote) Recover(info RecoverInfo) error {
+	if cmd.CheckIllegal(r.Password, r.Address, r.User, info.Name, info.Format) {
+		return buserr.New("ErrCmdIllegal")
+	}
 	fi, _ := os.Open(info.SourceFile)
 	defer fi.Close()
 

--- a/agent/utils/postgresql/client/remote.go
+++ b/agent/utils/postgresql/client/remote.go
@@ -14,6 +14,7 @@ import (
 	"github.com/1Panel-dev/1Panel/agent/app/model"
 	"github.com/1Panel-dev/1Panel/agent/global"
 	"github.com/1Panel-dev/1Panel/agent/i18n"
+	"github.com/1Panel-dev/1Panel/agent/utils/cmd"
 	"github.com/docker/docker/api/types/image"
 	"github.com/pkg/errors"
 
@@ -119,6 +120,9 @@ func (r *Remote) ChangePassword(info PasswordChangeInfo) error {
 }
 
 func (r *Remote) Backup(info BackupInfo) error {
+	if cmd.CheckIllegal(r.Password, r.Address, r.User, info.Name) {
+		return buserr.New("ErrCmdIllegal")
+	}
 	imageTag, err := loadImageTag(info.Database)
 	if err != nil {
 		return err
@@ -157,6 +161,9 @@ func (r *Remote) Backup(info BackupInfo) error {
 }
 
 func (r *Remote) Recover(info RecoverInfo) error {
+	if cmd.CheckIllegal(r.Password, r.Address, r.User, info.Name, info.Username) {
+		return buserr.New("ErrCmdIllegal")
+	}
 	imageTag, err := loadImageTag(info.Database)
 	if err != nil {
 		return err

--- a/agent/utils/toolbox/pure-ftpd.go
+++ b/agent/utils/toolbox/pure-ftpd.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/1Panel-dev/1Panel/agent/buserr"
 	"github.com/1Panel-dev/1Panel/agent/constant"
 	"github.com/1Panel-dev/1Panel/agent/global"
 	"github.com/1Panel-dev/1Panel/agent/utils/cmd"
@@ -99,6 +100,9 @@ func (f *Ftp) Operate(operate string) error {
 }
 
 func (f *Ftp) UserAdd(username, passwd, path string) error {
+	if cmd.CheckIllegal(username, path) {
+		return buserr.New("ErrCmdIllegal")
+	}
 	entry, err := generatePureFtpEntrySimple(username, passwd, path)
 	if err != nil {
 		return fmt.Errorf("generate pure-ftpd entry failed, err: %v", err)
@@ -121,6 +125,9 @@ func (f *Ftp) UserAdd(username, passwd, path string) error {
 }
 
 func (f *Ftp) UserDel(username string) error {
+	if cmd.CheckIllegal(username) {
+		return buserr.New("ErrCmdIllegal")
+	}
 	if err := cmd.RunDefaultBashCf("pure-pw userdel %s", username); err != nil {
 		return err
 	}
@@ -179,6 +186,9 @@ func (f *Ftp) SetPasswd(username, passwd string) error {
 }
 
 func (f *Ftp) SetPath(username, path string) error {
+	if cmd.CheckIllegal(username, path) {
+		return buserr.New("ErrCmdIllegal")
+	}
 	if err := cmd.RunDefaultBashCf("pure-pw usermod %s -d %s", username, path); err != nil {
 		return err
 	}
@@ -189,6 +199,9 @@ func (f *Ftp) SetPath(username, path string) error {
 }
 
 func (f *Ftp) SetStatus(username, status string) error {
+	if cmd.CheckIllegal(username, status) {
+		return buserr.New("ErrCmdIllegal")
+	}
 	statusItem := "''"
 	if status == constant.StatusDisable {
 		statusItem = "1"


### PR DESCRIPTION
#### What this PR does / why we need it?

[monkeycode](https://monkeycode-ai.com/) 发现了 1panel 的八个命令注入漏洞，修复之。

本 PR 修复了 8 个关键的命令注入漏洞，通过在多个 API 接口中添加输入验证，使用现有的 `CheckIllegal()` 函数来防止 shell 元字符被注入到系统命令中。

#### Summary of your change

在以下接口中，对用户可控参数拼接到 shell 命令之前添加了 `cmd.CheckIllegal()` 验证检查：

1. **SSH 日志查询** (`POST /hosts/ssh/log`) - 在 grep 拼接前验证 `req.Info` 参数
2. **iptables 规则搜索** (`POST /hosts/firewall/filter/rule/search`) - 在 `ReadFilterRulesByChain` 和 `LoadDefaultStrategy` 中验证 `chain` 参数
3. **Firewalld 端口转发** (`POST /hosts/firewall/port/forward`) - 验证 `operation`、`port`、`protocol`、`targetIP`、`targetPort` 参数
4. **Pure-FTPd 用户管理** - 在 `UserAdd`、`UserDel`、`SetPath`、`SetStatus` 函数中验证 `username` 和 `path` 参数
5. **PostgreSQL 远程备份** (`POST /databases/pg/backup`) - 在 `Backup` 和 `Recover` 函数中验证 `password`、`address`、`user`、`dbname` 参数
6. **MySQL 远程备份** (`POST /databases/backup`) - 在 `Backup` 和 `Recover` 函数中验证 `password`、`address`、`user`、`dbname`、`format` 参数
7. **Website Composer** (`POST /websites/php/composer`) - 验证 `user`、`mirror`、`command`、`extCommand` 参数
8. **磁盘操作** (`POST /disk/partition`) - 在 `PartitionDisk`、`MountDisk`、`UnmountDisk` 函数中验证 `device`、`mountPoint`、`filesystem`、`label` 参数

所有验证在检测到 shell 元字符（`& | ; $ ' ` ( ) " \n \r > <`）时返回 `buserr.New("ErrCmdIllegal")`，阻止命令执行。

**修改的文件：**
- `agent/app/service/ssh.go`
- `agent/app/service/disk.go`
- `agent/app/service/website.go`
- `agent/utils/firewall/client/firewalld.go`
- `agent/utils/firewall/client/iptables/filter.go`
- `agent/utils/mysql/client/remote.go`
- `agent/utils/postgresql/client/remote.go`
- `agent/utils/toolbox/pure-ftpd.go`

#### Please indicate you've done the following:

- [x] 确保测试通过，并在需要时添加了测试覆盖
- [x] 确保提交信息遵循 [Conventional Commits 规范](https://www.conventionalcommits.org/)
- [ ] 考虑了文档影响，并在需要时开启了新的文档 issue 或 PR