### PR TITLE
feat: Add support for Technitium DNS server

### DIFF
--- a/agent/utils/ssl/dns_provider.go
+++ b/agent/utils/ssl/dns_provider.go
@@ -2,6 +2,8 @@ package ssl
 
 import (
 	"encoding/json"
+	"time"
+
 	"github.com/go-acme/lego/v4/challenge"
 	"github.com/go-acme/lego/v4/providers/dns/acmedns"
 	"github.com/go-acme/lego/v4/providers/dns/alidns"
@@ -24,11 +26,11 @@ import (
 	"github.com/go-acme/lego/v4/providers/dns/regru"
 	"github.com/go-acme/lego/v4/providers/dns/route53"
 	"github.com/go-acme/lego/v4/providers/dns/spaceship"
+	"github.com/go-acme/lego/v4/providers/dns/technitium"
 	"github.com/go-acme/lego/v4/providers/dns/tencentcloud"
 	"github.com/go-acme/lego/v4/providers/dns/vercel"
 	"github.com/go-acme/lego/v4/providers/dns/volcengine"
 	"github.com/go-acme/lego/v4/providers/dns/westcn"
-	"time"
 )
 
 type DnsType string
@@ -59,6 +61,7 @@ const (
 	Ovh          DnsType = "Ovh"
 	AcmeDNS      DnsType = "AcmeDNS"
 	PorkBun      DnsType = "PorkBun"
+	Technitium	 DnsType = "Technitium"
 )
 
 type DNSParam struct {
@@ -301,6 +304,14 @@ func getDNSProviderConfig(dnsType DnsType, params string) (challenge.Provider, e
 		config.PollingInterval = pollingInterval
 		config.TTL = ttl
 		p, err = porkbun.NewDNSProviderConfig(config)
+	case Technitium:
+		config := technitium.NewDefaultConfig()
+		config.BaseURL = param.BaseURL
+		config.APIToken = param.Token
+		config.PropagationTimeout = propagationTimeout
+		config.PollingInterval = pollingInterval
+		config.TTL = ttl
+		p, err = technitium.NewDNSProviderConfig(config)
 	}
 
 	if err != nil {

--- a/agent/utils/ssl/dns_provider.go
+++ b/agent/utils/ssl/dns_provider.go
@@ -2,8 +2,6 @@ package ssl
 
 import (
 	"encoding/json"
-	"time"
-
 	"github.com/go-acme/lego/v4/challenge"
 	"github.com/go-acme/lego/v4/providers/dns/acmedns"
 	"github.com/go-acme/lego/v4/providers/dns/alidns"
@@ -31,6 +29,7 @@ import (
 	"github.com/go-acme/lego/v4/providers/dns/vercel"
 	"github.com/go-acme/lego/v4/providers/dns/volcengine"
 	"github.com/go-acme/lego/v4/providers/dns/westcn"
+	"time"
 )
 
 type DnsType string

--- a/frontend/src/global/mimetype.ts
+++ b/frontend/src/global/mimetype.ts
@@ -272,6 +272,10 @@ export const DNSTypes = [
         label: 'DNSPod (' + i18n.global.t('ssl.deprecated') + ')',
         value: 'DnsPod',
     },
+    {
+        label: 'Technitium',
+        value: 'Technitium',
+    },
 ];
 
 export const Fields = [

--- a/frontend/src/views/website/ssl/dns-account/create/index.vue
+++ b/frontend/src/views/website/ssl/dns-account/create/index.vue
@@ -183,6 +183,14 @@
                             <el-input v-model.trim="account.authorization['secretKey']"></el-input>
                         </el-form-item>
                     </div>
+                    <div v-if="account.type === 'Technitium'">
+                        <el-form-item label="BASE URL" prop="authorization.baseURL" :rules="[Rules.requiredInput]">
+                            <el-input v-model.trim="account.authorization['baseURL']"></el-input>
+                        </el-form-item>
+                        <el-form-item label="Token" prop="authorization.token">
+                            <el-input v-model.trim="account.authorization['token']"></el-input>
+                        </el-form-item>
+                    </div>
                 </el-form>
             </el-col>
         </el-row>


### PR DESCRIPTION
#### What this PR does / why we need it?
It adds support for [Technitium DNS server](https://technitium.com/) (a popular self-hosted option) for ACME DNS challenge.

#### Summary of your change
Simply exposes the Technitium functionality from the [Go-ACME Lego library](https://github.com/go-acme/lego/tree/v4.30.1/providers/dns/technitium) and adds its configuration to the Websites/Certificates/DNS Providers UI. 

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.