### PR TITLE
chore: change esbuild to native version

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -95,6 +95,8 @@
         "vue-tsc": "^0.29.8"
     },
     "trustedDependencies": [
+        "@parcel/watcher",
+        "esbuild",
         "@vue-office/docx",
         "@vue-office/excel"
     ],

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -98,9 +98,6 @@
         "@vue-office/docx",
         "@vue-office/excel"
     ],
-    "overrides": {
-        "esbuild": "npm:esbuild-wasm@latest"
-    },
     "config": {
         "commitizen": {
             "path": "node_modules/cz-git"


### PR DESCRIPTION
#### What this PR does / why we need it?
https://github.com/1Panel-dev/1Panel/pull/1154
移除多余代码，取消esbuild wasm版本的覆写，改回native版本。
wasm为了兼容性，打包性能比native差了几个数量级，而之前pr里的架构现在官方全部都已经native支持
<img width="1269" height="764" alt="image" src="https://github.com/user-attachments/assets/729c8f13-046f-4046-8499-5153122617eb" />

