### PR TITLE
fix: restore subsite nginx config on start to avoid stale stop page

### DIFF
--- a/agent/app/service/website_utils.go
+++ b/agent/app/service/website_utils.go
@@ -1048,6 +1048,31 @@ func opWebsite(website *model.Website, operate string) error {
 				proxy := fmt.Sprintf("http://%s", website.Proxy)
 				server.UpdateRootProxy([]string{proxy})
 			}
+		case constant.Subsite:
+			parentWebsite, err := websiteRepo.GetFirst(repo.WithByID(website.ParentWebsiteID))
+			if err != nil {
+				return err
+			}
+			website.Proxy = parentWebsite.Proxy
+			rootIndex = path.Join("/www/sites", parentWebsite.Alias, "index", website.SiteDir)
+			if parentWebsite.Type == constant.Runtime {
+				parentRuntime, err := runtimeRepo.GetFirst(context.Background(), repo.WithByID(parentWebsite.RuntimeID))
+				if err != nil {
+					return err
+				}
+				website.RuntimeID = parentRuntime.ID
+				if parentRuntime.Type == constant.RuntimePHP {
+					server.UpdateRoot(rootIndex)
+					localPath := ""
+					if parentRuntime.Resource == constant.ResourceLocal {
+						localPath = path.Join(rootIndex, "index.php")
+					}
+					server.UpdatePHPProxy([]string{website.Proxy}, localPath)
+				}
+			}
+			if parentWebsite.Type == constant.Static {
+				server.UpdateRoot(rootIndex)
+			}
 		}
 		website.Status = constant.WebRunning
 		now := time.Now()


### PR DESCRIPTION
#### What this PR does / why we need it?
修复子网站在“停止后再启动”场景下无法恢复访问的问题。子网站被停止后会命中停站页，但再次启动时未正确恢复对应 Nginx 配置，导致持续显示停站提示。 #11669 
#### Summary of your change
在网站启动逻辑中补充 subsite 分支处理，按父站点类型恢复子网站 root 与代理配置，父站点为 PHP 运行时时恢复对应 PHP 转发配置，同步必要运行字段，确保状态与配置一致。
#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.