### PR TITLE
fix: open compressed files in decompress drawer, improve archive detection

### DIFF
--- a/frontend/src/views/host/file-management/index.vue
+++ b/frontend/src/views/host/file-management/index.vue
@@ -480,7 +480,7 @@
                                             <svg-icon
                                                 v-else
                                                 className="table-icon"
-                                                :iconName="getIconName(row.extension)"
+                                                :iconName="getIconName(row.name, row.extension)"
                                             ></svg-icon>
                                         </div>
                                         <div class="file-name">
@@ -696,7 +696,7 @@ import Convert from './convert/index.vue';
 import { debounce } from 'lodash-es';
 import TerminalDialog from './terminal/index.vue';
 import { Dashboard } from '@/api/interface/dashboard';
-import { CompressExtension, CompressType } from '@/enums/files';
+import { CompressExtension, MimetypeByExtensionObject } from '@/enums/files';
 import type { TabPaneName } from 'element-plus';
 import { getComponentInfo } from '@/api/modules/host';
 import { routerToNameWithQuery } from '@/utils/router';
@@ -1195,8 +1195,8 @@ const calculateSize = (path: string) => {
     }, 0);
 };
 
-const getIconName = (extension: string) => {
-    return getIcon(extension);
+const getIconName = (name: string, extension: string) => {
+    return getIcon(getFileExtension(name, extension));
 };
 
 const openMode = (item: File.File) => {
@@ -1224,16 +1224,18 @@ const openCompress = (items: File.File[]) => {
 };
 
 const openDeCompress = (item: File.File) => {
-    if (Mimetypes.get(item.mimeType) == undefined) {
+    const extension = getFileExtension(item.name, item.extension);
+    const mimeType = item.mimeType || MimetypeByExtensionObject[extension];
+    const typeByMime = mimeType ? Mimetypes.get(mimeType) : undefined;
+    const typeByExtension = getEnumKeyByValue(extension);
+
+    if (typeByMime && (!typeByExtension || CompressExtension[typeByMime] === extension)) {
+        fileDeCompress.type = typeByMime;
+    } else if (typeByExtension) {
+        fileDeCompress.type = typeByExtension;
+    } else {
         MsgWarning(i18n.global.t('file.canNotDeCompress'));
         return;
-    }
-    fileDeCompress.type = Mimetypes.get(item.mimeType);
-    if (CompressExtension[Mimetypes.get(item.mimeType)] != item.extension) {
-        fileDeCompress.type = getEnumKeyByValue(item.extension);
-    }
-    if (item.name.endsWith('.tar.gz') || item.name.endsWith('.tgz')) {
-        fileDeCompress.type = CompressType.TarGz;
     }
 
     fileDeCompress.name = item.name;
@@ -1244,10 +1246,28 @@ const openDeCompress = (item: File.File) => {
 };
 
 function getEnumKeyByValue(value: string): keyof typeof CompressExtension | undefined {
+    const normalizedValue = value.toLowerCase();
     return (Object.keys(CompressExtension) as Array<keyof typeof CompressExtension>).find(
-        (k) => CompressExtension[k] === value,
+        (k) => CompressExtension[k] === normalizedValue,
     );
 }
+
+const sortedCompressExtensions = Object.values(CompressExtension).sort((a, b) => b.length - a.length);
+
+const getFileExtension = (name: string, extension?: string): string => {
+    const lowerName = name?.toLowerCase() ?? '';
+    const compoundMatch = sortedCompressExtensions.find((compressExtension) => lowerName.endsWith(compressExtension));
+    if (compoundMatch) {
+        return compoundMatch;
+    }
+
+    if (extension) {
+        return extension.toLowerCase();
+    }
+
+    const extensionIndex = lowerName.lastIndexOf('.');
+    return extensionIndex === -1 ? '' : lowerName.slice(extensionIndex);
+};
 
 const openView = (item: File.File) => {
     const fileType = getFileType(item.extension);
@@ -1263,14 +1283,17 @@ const openView = (item: File.File) => {
         return openPreview(item, fileType);
     }
 
+    if (fileType === 'compress') {
+        return openDeCompress(item);
+    }
+
     const path = item.isSymlink ? item.linkPath : item.path;
     if (item.size > MAX_OPEN_SIZE) {
         return openTextPreview(path, item.name);
     }
 
     const actionMap = {
-        compress: openDeCompress,
-        text: () => openCodeEditor(item.path, item.extension),
+        text: () => openCodeEditor(path, item.extension),
     };
 
     return actionMap[fileType] ? actionMap[fileType](item) : openCodeEditor(path, item.extension);
@@ -1549,8 +1572,11 @@ const toFavorite = (row: File.Favorite) => {
         jump(row.path);
     } else {
         let file = {} as File.File;
+        const extension = getFileExtension(row.name);
         file.path = row.path;
-        file.extension = '.' + row.name.split('.').pop();
+        file.name = row.name;
+        file.extension = extension;
+        file.mimeType = MimetypeByExtensionObject[extension] || '';
         openView(file);
     }
 };
@@ -1586,7 +1612,7 @@ const beforeButtons = [
         label: i18n.global.t('commons.button.open'),
         click: open,
         show: (row: File.File) => {
-            return row?.isDir || row?.size <= MAX_OPEN_SIZE;
+            return row?.isDir || row?.size <= MAX_OPEN_SIZE || isDecompressFile(row);
         },
     },
     {
@@ -1596,7 +1622,7 @@ const beforeButtons = [
             openTextPreview(path, row.name);
         },
         show: (row: File.File) => {
-            return !row?.isDir && row?.size > MAX_OPEN_SIZE;
+            return !row?.isDir && row?.size > MAX_OPEN_SIZE && !isDecompressFile(row);
         },
     },
     {


### PR DESCRIPTION
#### What this PR does / why we need it?
修复文件管理与压缩文件打开行为相关的问题（#11952）：
- 点击压缩文件应直接打开解压抽屉，不应进入预览抽屉。
- 优化压缩包类型识别，提升复合后缀场景的稳定性。
- 修复文件管理器列表中压缩文件图标识别不准确的问题。

#### Summary of your change
- 调整文件打开逻辑优先级：在大文件预览判断前，优先处理 `compress` 类型并进入解压流程。
- 通过统一扩展名解析支持 `.tar.gz/.tar.bz2/.tar.xz` 等复合后缀。
- 修复收藏夹中打开文件时参数不完整问题，补全 `name/path/extension/mimeType`，保证与列表行为一致。
- 调整右键按钮显示逻辑可解压的压缩包显示 `打开`，不再显示“预览”。
- 调整文件管理器主列表图标识别逻辑，确保压缩文件显示压缩包图标。

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.