### PR TITLE
fix: avoid pre-sanitizing markdown source

### DIFF
--- a/frontend/src/components/mkdown-editor/index.vue
+++ b/frontend/src/components/mkdown-editor/index.vue
@@ -1,5 +1,10 @@
 <template>
-    <MdEditor previewOnly v-model="sanitizedReadMe" :theme="isDarkTheme ? 'dark' : 'light'" />
+    <MdEditor
+        previewOnly
+        :model-value="props.content"
+        :sanitize="sanitizeHtml"
+        :theme="isDarkTheme ? 'dark' : 'light'"
+    />
 </template>
 
 <script lang="ts" setup>
@@ -17,7 +22,7 @@ const props = defineProps({
     },
 });
 
-const sanitizedReadMe = computed(() => {
-    return DOMPurify.sanitize(props.content);
-});
+const sanitizeHtml = (html: string): string => {
+    return DOMPurify.sanitize(html);
+};
 </script>


### PR DESCRIPTION
#### What this PR does / why we need it?

关联 Issue: #11998
目标: 修复 Markdown 代码块中 </> 被过度防御转义的问题。
背景: 组件此前在 Markdown 渲染前先对原始内容做 DOMPurify.sanitize，会影响代码块文本显示。

#### Summary of your change

将 mkdown-editor 的输入从 v-model="sanitizedReadMe" 改为 :model-value="props.content"，不再预处理 Markdown 源文本。
新增 sanitizeHtml 并通过 :sanitize="sanitizeHtml" 交给 MdEditor 在 HTML 阶段进行消毒。

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.