### PR TITLE
feat: add pprof support for performance profiling in server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+
 GOCMD=go
 GOBUILD=$(GOCMD) build
 GOCLEAN=$(GOCMD) clean
@@ -44,6 +45,16 @@ build_agent_on_darwin:
 	cd $(AGENT_PATH) \
     &&  CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) -trimpath -ldflags '-s -w'  -o $(BUILD_PATH)/$(AGENT_NAME) $(AGENT_MAIN)
 
+build_pprof_core_on_linux:
+	cd $(CORE_PATH) \
+	&& CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) $(GOBUILD) -trimpath -tags pprof -ldflags '-s -w' -o $(BUILD_PATH)/$(CORE_NAME) $(CORE_MAIN)
+
+build_pprof_agent_on_linux:
+	cd $(AGENT_PATH) \
+	&& CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) $(GOBUILD) -trimpath -tags pprof -ldflags '-s -w' -o $(BUILD_PATH)/$(AGENT_NAME) $(AGENT_MAIN)
+
 build_all: build_frontend build_core_on_linux build_agent_on_linux
+
+build_pprof_all: build_frontend build_core_on_linux_pprof build_agent_on_linux_pprof
 
 build_on_local: clean_assets build_frontend build_core_on_darwin build_agent_on_darwin

--- a/agent/server/pprof.go
+++ b/agent/server/pprof.go
@@ -1,0 +1,24 @@
+//go:build pprof
+
+package server
+
+import (
+	"net/http"
+	_ "net/http/pprof"
+	"os"
+
+	"github.com/1Panel-dev/1Panel/agent/global"
+)
+
+func startPprof() {
+	addr := os.Getenv("1PANEL_PPROF_ADDR")
+	if addr == "" {
+		addr = ":6061"
+	}
+	go func() {
+		global.LOG.Infof("pprof server listening on %s", addr)
+		if err := http.ListenAndServe(addr, nil); err != nil {
+			global.LOG.Errorf("pprof server error: %v", err)
+		}
+	}()
+}

--- a/agent/server/pprof_disabled.go
+++ b/agent/server/pprof_disabled.go
@@ -1,0 +1,5 @@
+//go:build !pprof
+
+package server
+
+func startPprof() {}

--- a/agent/server/server.go
+++ b/agent/server/server.go
@@ -48,6 +48,7 @@ func Start() {
 	hook.Init()
 	go firewall.Init()
 	InitOthers()
+	startPprof()
 
 	rootRouter := router.Routers()
 

--- a/core/cmd/server/main.go
+++ b/core/cmd/server/main.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	_ "net/http/pprof"
-
 	"github.com/1Panel-dev/1Panel/core/cmd/server/cmd"
 	_ "github.com/1Panel-dev/1Panel/core/cmd/server/docs"
 )

--- a/core/server/pprof.go
+++ b/core/server/pprof.go
@@ -1,0 +1,24 @@
+//go:build pprof
+
+package server
+
+import (
+	"net/http"
+	_ "net/http/pprof"
+	"os"
+
+	"github.com/1Panel-dev/1Panel/core/global"
+)
+
+func startPprof() {
+	addr := os.Getenv("1PANEL_PPROF_ADDR")
+	if addr == "" {
+		addr = ":6060"
+	}
+	go func() {
+		global.LOG.Infof("pprof server listening on %s", addr)
+		if err := http.ListenAndServe(addr, nil); err != nil {
+			global.LOG.Errorf("pprof server error: %v", err)
+		}
+	}()
+}

--- a/core/server/pprof_disabled.go
+++ b/core/server/pprof_disabled.go
@@ -1,0 +1,5 @@
+//go:build !pprof
+
+package server
+
+func startPprof() {}

--- a/core/server/server.go
+++ b/core/server/server.go
@@ -49,6 +49,7 @@ func Start() {
 	session.Init()
 	hook.Init()
 	InitOthers()
+	startPprof()
 
 	run.Init()
 	proxy.Init()


### PR DESCRIPTION
#### What this PR does / why we need it?
翻代码的时候看到了core把pprof包给打进来了，pprof还是有一定开销的，引入生产似乎不妥


#### Summary of your change
通过tag选择性引用pprof, 需要调试的时候打pprof tag 去编译测试产物。

