### PR TITLE
fix: set sort_order for newly installed apps to avoid random positioning

### DIFF
--- a/agent/app/service/app.go
+++ b/agent/app/service/app.go
@@ -516,6 +516,10 @@ func (a AppService) Install(req request.AppInstallCreate, executeScript bool) (a
 	}
 	appInstall.Env = string(paramByte)
 
+	var maxSort int
+	global.DB.Model(&model.AppInstall{}).Where("favorite = ?", false).Select("COALESCE(MAX(sort_order),0)").Scan(&maxSort)
+	appInstall.SortOrder = maxSort + 1
+
 	if err = appInstallRepo.Create(context.Background(), appInstall); err != nil {
 		return
 	}


### PR DESCRIPTION
#### What this PR does / why we need it?

Newly installed apps have `sort_order` defaulting to 0, which causes them to appear at random positions among other apps that also have `sort_order = 0`. This fix assigns `sort_order = max(sort_order) + 1` at install time so new apps always appear at the end of the non-favorite list.

#### Summary of your change

- In `agent/app/service/app.go`, query the current max `sort_order` of non-favorite apps before creating the install record, and set the new app's `sort_order` to `max + 1`.

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.