### PR TITLE
feat: show SSL certificate issuer and expiry date in certificate selectors

### DIFF
--- a/frontend/src/views/ai/mcp/server/bind/index.vue
+++ b/frontend/src/views/ai/mcp/server/bind/index.vue
@@ -63,12 +63,15 @@
                         :placeholder="$t('website.selectSSL')"
                         @change="changeSSl(req.sslID)"
                     >
-                        <el-option
-                            v-for="(ssl, index) in ssls"
-                            :key="index"
-                            :label="ssl.primaryDomain"
-                            :value="ssl.id"
-                        ></el-option>
+                        <el-option v-for="(ssl, index) in ssls" :key="index" :label="ssl.primaryDomain" :value="ssl.id">
+                            <span>{{ ssl.primaryDomain }}</span>
+                            <el-tag class="tagClass" v-if="ssl.expireDate">
+                                {{ dateFormatSimple(ssl.expireDate) }}
+                            </el-tag>
+                            <el-tag class="tagClass" v-if="ssl.organization">
+                                {{ ssl.organization }}
+                            </el-tag>
+                        </el-option>
                     </el-select>
                 </el-form-item>
             </el-form>
@@ -90,15 +93,17 @@ import { listSSL, searchAcmeAccount } from '@/api/modules/website';
 import { Rules } from '@/global/form-rules';
 import { FormInstance, FormRules } from 'element-plus';
 import { reactive, ref } from 'vue';
-import { getAccountName } from '@/utils/util';
+import { getAccountName, dateFormatSimple } from '@/utils/util';
 import { bindMcpDomain, getMcpDomain, updateMcpDomain } from '@/api/modules/ai';
 import { MsgSuccess } from '@/utils/message';
 import i18n from '@/lang';
 
+type SSLItem = Website.SSL & { organization?: string };
+
 const open = ref(false);
 const operate = ref('create');
 const loading = ref(false);
-const ssls = ref([]);
+const ssls = ref<SSLItem[]>([]);
 const websiteSSL = ref<Website.SSL>();
 const acmeAccounts = ref();
 const formRef = ref();
@@ -224,5 +229,11 @@ defineExpose({
 .pageRoute {
     font-size: 12px;
     margin-left: 5px;
+}
+.tagClass {
+    float: right;
+    margin-right: 10px;
+    font-size: 12px;
+    margin-top: 5px;
 }
 </style>

--- a/frontend/src/views/ai/model/ollama/domain/index.vue
+++ b/frontend/src/views/ai/model/ollama/domain/index.vue
@@ -62,12 +62,15 @@
                         :placeholder="$t('website.selectSSL')"
                         @change="changeSSl(req.sslID)"
                     >
-                        <el-option
-                            v-for="(ssl, index) in ssls"
-                            :key="index"
-                            :label="ssl.primaryDomain"
-                            :value="ssl.id"
-                        ></el-option>
+                        <el-option v-for="(ssl, index) in ssls" :key="index" :label="ssl.primaryDomain" :value="ssl.id">
+                            <span>{{ ssl.primaryDomain }}</span>
+                            <el-tag class="tagClass" v-if="ssl.expireDate">
+                                {{ dateFormatSimple(ssl.expireDate) }}
+                            </el-tag>
+                            <el-tag class="tagClass" v-if="ssl.organization">
+                                {{ ssl.organization }}
+                            </el-tag>
+                        </el-option>
                     </el-select>
                 </el-form-item>
                 <el-alert :closable="false">
@@ -95,15 +98,17 @@ import { listSSL, searchAcmeAccount } from '@/api/modules/website';
 import { Rules } from '@/global/form-rules';
 import { FormInstance, FormRules } from 'element-plus';
 import { reactive, ref } from 'vue';
-import { getAccountName } from '@/utils/util';
+import { getAccountName, dateFormatSimple } from '@/utils/util';
 import { bindDomain, getBindDomain, updateBindDomain } from '@/api/modules/ai';
 import { MsgSuccess } from '@/utils/message';
 import i18n from '@/lang';
 
+type SSLItem = Website.SSL & { organization?: string };
+
 const open = ref(false);
 const operate = ref('create');
 const loading = ref(false);
-const ssls = ref([]);
+const ssls = ref<SSLItem[]>([]);
 const websiteSSL = ref<Website.SSL>();
 const acmeAccounts = ref();
 const formRef = ref();
@@ -238,5 +243,11 @@ defineExpose({
 .pageRoute {
     font-size: 12px;
     margin-left: 5px;
+}
+.tagClass {
+    float: right;
+    margin-right: 10px;
+    font-size: 12px;
+    margin-top: 5px;
 }
 </style>

--- a/frontend/src/views/website/website/components/https/index.vue
+++ b/frontend/src/views/website/website/components/https/index.vue
@@ -67,7 +67,15 @@
                         :label="ssl.primaryDomain"
                         :value="ssl.id"
                         :disabled="ssl.pem === ''"
-                    ></el-option>
+                    >
+                        <span>{{ ssl.primaryDomain }}</span>
+                        <el-tag class="tagClass" v-if="ssl.expireDate">
+                            {{ dateFormatSimple(ssl.expireDate) }}
+                        </el-tag>
+                        <el-tag class="tagClass" v-if="ssl.organization">
+                            {{ ssl.organization }}
+                        </el-tag>
+                    </el-option>
                 </el-select>
             </el-form-item>
         </div>
@@ -139,10 +147,12 @@
 
 <script lang="ts" setup>
 import { computed, watch, onMounted, ref } from 'vue';
-import { getAccountName } from '@/utils/util';
+import { getAccountName, dateFormatSimple } from '@/utils/util';
 import WebsiteSSL from '@/views/website/website/components/website-ssl/index.vue';
 import { Website } from '@/api/interface/website';
 import { listSSL, searchAcmeAccount } from '@/api/modules/website';
+
+type SSLItem = Website.SSL & { organization?: string };
 
 interface AcmeAccount {
     id: number;
@@ -187,7 +197,7 @@ const props = withDefaults(defineProps<Props>(), {
 const emit = defineEmits<Emits>();
 
 const acmeAccounts = ref<AcmeAccount[]>([]);
-const ssls = ref<Website.SSL[]>([]);
+const ssls = ref<SSLItem[]>([]);
 const keyFileRef = ref();
 const certFileRef = ref();
 
@@ -297,5 +307,11 @@ onMounted(() => {
     margin-left: 8px;
     color: var(--el-text-color-secondary);
     font-size: 12px;
+}
+.tagClass {
+    float: right;
+    margin-right: 10px;
+    font-size: 12px;
+    margin-top: 5px;
 }
 </style>

--- a/frontend/src/views/website/website/create/index.vue
+++ b/frontend/src/views/website/website/create/index.vue
@@ -255,7 +255,15 @@
                                     :label="ssl.primaryDomain"
                                     :value="ssl.id"
                                     :disabled="ssl.pem == ''"
-                                ></el-option>
+                                >
+                                    <span>{{ ssl.primaryDomain }}</span>
+                                    <el-tag class="tagClass" v-if="ssl.expireDate">
+                                        {{ dateFormatSimple(ssl.expireDate) }}
+                                    </el-tag>
+                                    <el-tag class="tagClass" v-if="ssl.organization">
+                                        {{ ssl.organization }}
+                                    </el-tag>
+                                </el-option>
                             </el-select>
                         </el-form-item>
                         <el-form-item :label="' '" v-if="websiteSSL && websiteSSL.id > 0">
@@ -443,7 +451,7 @@ import { reactive, ref, watch } from 'vue';
 import { MsgError, MsgSuccess } from '@/utils/message';
 import { SearchRuntimes } from '@/api/modules/runtime';
 import { Runtime } from '@/api/interface/runtime';
-import { getRandomStr, getRuntimeLabel } from '@/utils/util';
+import { getRandomStr, getRuntimeLabel, dateFormatSimple } from '@/utils/util';
 import { getAppService } from '@/api/modules/app';
 import { v4 as uuidv4 } from 'uuid';
 import { getAccountName } from '@/utils/util';
@@ -1097,5 +1105,11 @@ defineExpose({
     text-overflow: ellipsis;
     white-space: nowrap;
     display: inline-block;
+}
+.tagClass {
+    float: right;
+    margin-right: 10px;
+    font-size: 12px;
+    margin-top: 5px;
 }
 </style>


### PR DESCRIPTION
#### What this PR does / why we need it?

When selecting an SSL certificate from the dropdown, only the primary domain is shown, making it difficult to distinguish between multiple certificates. This PR adds the certificate issuer (organization) and expiry date as tags in the dropdown options, helping users quickly identify the correct certificate.

#### Summary of your change

- Added `organization` and `expireDate` display as `el-tag` in all 4 SSL certificate selector dropdowns, following the same `tagClass` pattern used in cronjob's backup database selector.
- Added `SSLItem` type definition for strict TypeScript compatibility.
- Files changed:
  - `frontend/src/views/website/website/components/https/index.vue`
  - `frontend/src/views/website/website/create/index.vue`
  - `frontend/src/views/ai/mcp/server/bind/index.vue`
  - `frontend/src/views/ai/model/ollama/domain/index.vue`

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
