### PR TITLE
fix: 修复删除多个文件夹时确认按钮不显示加载态的问题，并减少删除时不必要的`basedir`请求

### DIFF
--- a/frontend/src/views/host/file-management/delete/index.vue
+++ b/frontend/src/views/host/file-management/delete/index.vue
@@ -46,7 +46,7 @@
                 <el-button @click="open = false" :disabled="loading">
                     {{ $t('commons.button.cancel') }}
                 </el-button>
-                <el-button type="primary" @click="onConfirm" :disabled="loading">
+                <el-button type="primary" @click="onConfirm" :loading="loading" :disabled="loading">
                     {{ $t('commons.button.confirm') }}
                 </el-button>
             </span>
@@ -101,37 +101,43 @@ const getStatus = async () => {
 };
 
 const onConfirm = async () => {
-    const pros = [];
-    for (const s of files.value) {
-        if (s['isDir']) {
-            if (s['path'].indexOf('.1panel_clash') > -1) {
-                MsgWarning(i18n.global.t('file.clashDeleteAlert'));
-                return;
-            }
-            const pathRes = await loadBaseDir();
-            if (s['path'] === pathRes.data) {
-                MsgWarning(i18n.global.t('file.panelInstallDir'));
-                return;
-            }
-        }
-        if (reqNode.value != '') {
-            pros.push(
-                deleteFileByNode({ path: s['path'], isDir: s['isDir'], forceDelete: forceDelete.value }, reqNode.value),
-            );
-        } else {
-            pros.push(deleteFile({ path: s['path'], isDir: s['isDir'], forceDelete: forceDelete.value }));
-        }
-    }
     loading.value = true;
-    Promise.all(pros)
-        .then(() => {
-            MsgSuccess(i18n.global.t('commons.msg.deleteSuccess'));
-            open.value = false;
-            em('close');
-        })
-        .finally(() => {
-            loading.value = false;
-        });
+    try {
+        const pros = [];
+        let baseDir = '';
+        if (files.value.some((item) => item['isDir'])) {
+            const pathRes = await loadBaseDir();
+            baseDir = pathRes.data;
+        }
+        for (const s of files.value) {
+            if (s['isDir']) {
+                if (s['path'].indexOf('.1panel_clash') > -1) {
+                    MsgWarning(i18n.global.t('file.clashDeleteAlert'));
+                    return;
+                }
+                if (s['path'] === baseDir) {
+                    MsgWarning(i18n.global.t('file.panelInstallDir'));
+                    return;
+                }
+            }
+            if (reqNode.value != '') {
+                pros.push(
+                    deleteFileByNode(
+                        { path: s['path'], isDir: s['isDir'], forceDelete: forceDelete.value },
+                        reqNode.value,
+                    ),
+                );
+            } else {
+                pros.push(deleteFile({ path: s['path'], isDir: s['isDir'], forceDelete: forceDelete.value }));
+            }
+        }
+        await Promise.all(pros);
+        MsgSuccess(i18n.global.t('commons.msg.deleteSuccess'));
+        open.value = false;
+        em('close');
+    } finally {
+        loading.value = false;
+    }
 };
 
 const getIconName = (extension: string) => {


### PR DESCRIPTION
#### What this PR does / why we need it?

在删除大量文件夹时，删除对话框的确认按钮不会变为加载态，这会让用户以为删除操作始终未开始，影响用户操作，如果用户继续点击会出现大量并发重复的删除请求。
另外，删除每个文件夹时都会请求`basedir`api，在删除多个文件夹时会造成大量重复请求。

![PixPin_2026-03-16_17-39-46](https://github.com/user-attachments/assets/2348f4a9-5f78-4d7e-ad81-abc7d7d4ae86)

#### Summary of your change

- 为按钮添加加载态，`loading.value = true;`原来的位置有问题，已提前至删除操作的顶部
- 每次整个删除操作只请求一次`basedir`

![PixPin_2026-03-16_17-42-25](https://github.com/user-attachments/assets/48a6ce2f-0573-4f1a-8013-690ac6e2c63c)


#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.