### PR TITLE
feat: add SSL verification option to website proxy configuration

### DIFF
--- a/agent/app/dto/request/website.go
+++ b/agent/app/dto/request/website.go
@@ -269,6 +269,7 @@ type WebsiteProxyConfig struct {
 	Replaces        map[string]string `json:"replaces"`
 	SNI             bool              `json:"sni"`
 	ProxySSLName    string            `json:"proxySSLName"`
+	SSLVerify       bool              `json:"sslVerify"`
 	CorsConfig
 }
 

--- a/agent/app/service/website_proxy.go
+++ b/agent/app/service/website_proxy.go
@@ -115,6 +115,11 @@ func (w WebsiteService) OperateProxy(req request.WebsiteProxyConfig) (err error)
 		return
 	}
 	applyLocationProxyPass(location, req.ProxyPass, &req.SNI, req.ProxySSLName)
+	if isHTTPSProxyPass(req.ProxyPass) && req.SSLVerify {
+		location.UpdateDirective("proxy_ssl_verify", []string{"on"})
+	} else {
+		location.RemoveDirective("proxy_ssl_verify", []string{})
+	}
 	location.UpdateDirective("proxy_set_header", []string{"Host", req.ProxyHost})
 	location.ChangePath(req.Modifier, req.Match)
 	// Server Cache Settings
@@ -328,6 +333,9 @@ func (w WebsiteService) GetProxies(id uint) (res []request.WebsiteProxyConfig, e
 			}
 			if directive.GetName() == "proxy_ssl_name" && len(directive.GetParameters()) > 0 {
 				proxyConfig.ProxySSLName = directive.GetParameters()[0]
+			}
+			if directive.GetName() == "proxy_ssl_verify" {
+				proxyConfig.SSLVerify = len(directive.GetParameters()) > 0 && directive.GetParameters()[0] == "on"
 			}
 		}
 		proxyConfig.Cors = location.Cors

--- a/frontend/src/api/interface/website.ts
+++ b/frontend/src/api/interface/website.ts
@@ -439,6 +439,7 @@ export namespace Website {
         proxyProtocol?: string;
         sni?: boolean;
         proxySSLName: string;
+        sslVerify?: boolean;
         cors: boolean;
         allowOrigins: string;
         allowMethods: string;

--- a/frontend/src/lang/modules/en.ts
+++ b/frontend/src/lang/modules/en.ts
@@ -2760,7 +2760,8 @@ const message = {
         sniHelper:
             "When the reverse proxy backend is HTTPS, you might need to set the origin SNI. See the CDN service provider's documentation for details.",
         proxySslVerify: 'Verify Backend SSL Certificate',
-        proxySslVerifyHelper: 'When enabled, the proxy will strictly verify the upstream SSL certificate (disabled by default).',
+        proxySslVerifyHelper:
+            'When enabled, the proxy will strictly verify the upstream SSL certificate (disabled by default).',
         huaweicloud: 'Huawei Cloud',
         createDb: 'Create Database',
         enableSSLHelper: 'Failure to enable will not affect the creation of the website',

--- a/frontend/src/lang/modules/en.ts
+++ b/frontend/src/lang/modules/en.ts
@@ -2759,6 +2759,8 @@ const message = {
         sni: 'Origin SNI',
         sniHelper:
             "When the reverse proxy backend is HTTPS, you might need to set the origin SNI. See the CDN service provider's documentation for details.",
+        proxySslVerify: 'Verify Backend SSL Certificate',
+        proxySslVerifyHelper: 'When enabled, the proxy will strictly verify the upstream SSL certificate (disabled by default).',
         huaweicloud: 'Huawei Cloud',
         createDb: 'Create Database',
         enableSSLHelper: 'Failure to enable will not affect the creation of the website',

--- a/frontend/src/lang/modules/es-es.ts
+++ b/frontend/src/lang/modules/es-es.ts
@@ -2794,6 +2794,8 @@ const message = {
         sni: 'SNI de origen',
         sniHelper:
             'Cuando el backend proxy es HTTPS, puede ser necesario configurar el SNI. Consulta la doc del proveedor CDN.',
+        proxySslVerify: 'Verify Backend SSL Certificate',
+        proxySslVerifyHelper: 'When enabled, the proxy will strictly verify the upstream SSL certificate (disabled by default).',
         huaweicloud: 'Huawei Cloud',
         createDb: 'Crear base de datos',
         enableSSLHelper: 'Si falla, no afectará la creación del sitio',

--- a/frontend/src/lang/modules/es-es.ts
+++ b/frontend/src/lang/modules/es-es.ts
@@ -2794,8 +2794,9 @@ const message = {
         sni: 'SNI de origen',
         sniHelper:
             'Cuando el backend proxy es HTTPS, puede ser necesario configurar el SNI. Consulta la doc del proveedor CDN.',
-        proxySslVerify: 'Verify Backend SSL Certificate',
-        proxySslVerifyHelper: 'When enabled, the proxy will strictly verify the upstream SSL certificate (disabled by default).',
+        proxySslVerify: 'Verificar certificado SSL del backend',
+        proxySslVerifyHelper:
+            'Si está activada, el proxy verificará estrictamente el certificado SSL del servidor de origen (desactivada por defecto).',
         huaweicloud: 'Huawei Cloud',
         createDb: 'Crear base de datos',
         enableSSLHelper: 'Si falla, no afectará la creación del sitio',

--- a/frontend/src/lang/modules/ja.ts
+++ b/frontend/src/lang/modules/ja.ts
@@ -2781,6 +2781,8 @@ const message = {
         sni: '起源は悲しい',
         sniHelper:
             '逆プロキシバックエンドがHTTPSの場合、Origin SNIを設定する必要がある場合があります。詳細については、CDNサービスプロバイダーのドキュメントを参照してください。',
+        proxySslVerify: 'Verify Backend SSL Certificate',
+        proxySslVerifyHelper: 'When enabled, the proxy will strictly verify the upstream SSL certificate (disabled by default).',
         huaweicloud: 'huaweiCloud',
         createDb: 'データベースを作成',
         enableSSLHelper: 'SSLの有効化に失敗しても、ウェブサイトの作成には影響しません。',

--- a/frontend/src/lang/modules/ja.ts
+++ b/frontend/src/lang/modules/ja.ts
@@ -2781,8 +2781,8 @@ const message = {
         sni: '起源は悲しい',
         sniHelper:
             '逆プロキシバックエンドがHTTPSの場合、Origin SNIを設定する必要がある場合があります。詳細については、CDNサービスプロバイダーのドキュメントを参照してください。',
-        proxySslVerify: 'Verify Backend SSL Certificate',
-        proxySslVerifyHelper: 'When enabled, the proxy will strictly verify the upstream SSL certificate (disabled by default).',
+        proxySslVerify: 'バックエンド SSL 証明書を検証',
+        proxySslVerifyHelper: '有効にすると、プロキシは上流の SSL 証明書を厳格に検証します（既定では無効）。',
         huaweicloud: 'huaweiCloud',
         createDb: 'データベースを作成',
         enableSSLHelper: 'SSLの有効化に失敗しても、ウェブサイトの作成には影響しません。',

--- a/frontend/src/lang/modules/ko.ts
+++ b/frontend/src/lang/modules/ko.ts
@@ -2715,8 +2715,8 @@ const message = {
         sni: '원본 SNI',
         sniHelper:
             '역방향 프록시 백엔드가 HTTPS 인 경우 원본 SNI 를 설정해야 할 수 있습니다. 자세한 내용은 CDN 서비스 제공자의 문서를 참조하세요.',
-        proxySslVerify: 'Verify Backend SSL Certificate',
-        proxySslVerifyHelper: 'When enabled, the proxy will strictly verify the upstream SSL certificate (disabled by default).',
+        proxySslVerify: '백엔드 SSL 인증서 검증',
+        proxySslVerifyHelper: '활성화하면 프록시가 업스트림 SSL 인증서를 엄격하게 검증합니다(기본값은 비활성화).',
         huaweicloud: '화웨이 클라우드',
         createDb: '데이터베이스 생성',
         enableSSLHelper: 'SSL 활성화 실패는 웹사이트 생성에 영향을 미치지 않습니다.',

--- a/frontend/src/lang/modules/ko.ts
+++ b/frontend/src/lang/modules/ko.ts
@@ -2715,6 +2715,8 @@ const message = {
         sni: '원본 SNI',
         sniHelper:
             '역방향 프록시 백엔드가 HTTPS 인 경우 원본 SNI 를 설정해야 할 수 있습니다. 자세한 내용은 CDN 서비스 제공자의 문서를 참조하세요.',
+        proxySslVerify: 'Verify Backend SSL Certificate',
+        proxySslVerifyHelper: 'When enabled, the proxy will strictly verify the upstream SSL certificate (disabled by default).',
         huaweicloud: '화웨이 클라우드',
         createDb: '데이터베이스 생성',
         enableSSLHelper: 'SSL 활성화 실패는 웹사이트 생성에 영향을 미치지 않습니다.',

--- a/frontend/src/lang/modules/ms.ts
+++ b/frontend/src/lang/modules/ms.ts
@@ -2811,6 +2811,8 @@ const message = {
         sni: 'Sumber SNI',
         sniHelper:
             'Apabila backend proksi terbalik adalah HTTPS, anda mungkin perlu menetapkan sumber SNI. Sila rujuk dokumentasi penyedia perkhidmatan CDN untuk butiran.',
+        proxySslVerify: 'Verify Backend SSL Certificate',
+        proxySslVerifyHelper: 'When enabled, the proxy will strictly verify the upstream SSL certificate (disabled by default).',
         huaweicloud: 'Huawei Cloud',
         createDb: 'Cipta Pangkalan Data',
         enableSSLHelper: 'Kegagalan mengaktifkan SSL tidak akan menjejaskan penciptaan laman web.',

--- a/frontend/src/lang/modules/ms.ts
+++ b/frontend/src/lang/modules/ms.ts
@@ -2811,8 +2811,9 @@ const message = {
         sni: 'Sumber SNI',
         sniHelper:
             'Apabila backend proksi terbalik adalah HTTPS, anda mungkin perlu menetapkan sumber SNI. Sila rujuk dokumentasi penyedia perkhidmatan CDN untuk butiran.',
-        proxySslVerify: 'Verify Backend SSL Certificate',
-        proxySslVerifyHelper: 'When enabled, the proxy will strictly verify the upstream SSL certificate (disabled by default).',
+        proxySslVerify: 'Sahkan sijil SSL pelayan belakang',
+        proxySslVerifyHelper:
+            'Apabila diaktifkan, proksi akan mengesahkan sijil SSL hulu dengan ketat (lalai dimatikan).',
         huaweicloud: 'Huawei Cloud',
         createDb: 'Cipta Pangkalan Data',
         enableSSLHelper: 'Kegagalan mengaktifkan SSL tidak akan menjejaskan penciptaan laman web.',

--- a/frontend/src/lang/modules/pt-br.ts
+++ b/frontend/src/lang/modules/pt-br.ts
@@ -2951,8 +2951,9 @@ const message = {
         sni: 'SNI de origem',
         sniHelper:
             'Quando o proxy reverso de backend for HTTPS, você pode precisar configurar o SNI de origem. Consulte a documentação do provedor de serviços CDN para mais detalhes.',
-        proxySslVerify: 'Verify Backend SSL Certificate',
-        proxySslVerifyHelper: 'When enabled, the proxy will strictly verify the upstream SSL certificate (disabled by default).',
+        proxySslVerify: 'Verificar certificado SSL do backend',
+        proxySslVerifyHelper:
+            'Quando ativado, o proxy verificará estritamente o certificado SSL do servidor de origem (desativado por padrão).',
         huaweicloud: 'Huawei Cloud',
         createDb: 'Criar Banco de Dados',
         enableSSLHelper: 'A falha ao ativar o SSL não afetará a criação do site.',

--- a/frontend/src/lang/modules/pt-br.ts
+++ b/frontend/src/lang/modules/pt-br.ts
@@ -2951,6 +2951,8 @@ const message = {
         sni: 'SNI de origem',
         sniHelper:
             'Quando o proxy reverso de backend for HTTPS, você pode precisar configurar o SNI de origem. Consulte a documentação do provedor de serviços CDN para mais detalhes.',
+        proxySslVerify: 'Verify Backend SSL Certificate',
+        proxySslVerifyHelper: 'When enabled, the proxy will strictly verify the upstream SSL certificate (disabled by default).',
         huaweicloud: 'Huawei Cloud',
         createDb: 'Criar Banco de Dados',
         enableSSLHelper: 'A falha ao ativar o SSL não afetará a criação do site.',

--- a/frontend/src/lang/modules/ru.ts
+++ b/frontend/src/lang/modules/ru.ts
@@ -2811,6 +2811,8 @@ const message = {
         sni: 'Origin SNI',
         sniHelper:
             'Когда бэкенд обратного прокси использует HTTPS, может потребоваться установить origin SNI. Подробности см. в документации провайдера CDN.',
+        proxySslVerify: 'Verify Backend SSL Certificate',
+        proxySslVerifyHelper: 'When enabled, the proxy will strictly verify the upstream SSL certificate (disabled by default).',
         huaweicloud: 'Huawei Cloud',
         rcreateDb: 'Создать Базу Данных',
         enableSSLHelper: 'Неудача при включении SSL не повлияет на создание сайта.',

--- a/frontend/src/lang/modules/ru.ts
+++ b/frontend/src/lang/modules/ru.ts
@@ -2811,8 +2811,9 @@ const message = {
         sni: 'Origin SNI',
         sniHelper:
             'Когда бэкенд обратного прокси использует HTTPS, может потребоваться установить origin SNI. Подробности см. в документации провайдера CDN.',
-        proxySslVerify: 'Verify Backend SSL Certificate',
-        proxySslVerifyHelper: 'When enabled, the proxy will strictly verify the upstream SSL certificate (disabled by default).',
+        proxySslVerify: 'Проверять SSL-сертификат бэкенда',
+        proxySslVerifyHelper:
+            'При включении прокси строго проверяет SSL-сертификат вышестоящего сервера (по умолчанию отключено).',
         huaweicloud: 'Huawei Cloud',
         rcreateDb: 'Создать Базу Данных',
         enableSSLHelper: 'Неудача при включении SSL не повлияет на создание сайта.',

--- a/frontend/src/lang/modules/tr.ts
+++ b/frontend/src/lang/modules/tr.ts
@@ -2809,6 +2809,8 @@ const message = {
         sni: 'Kaynak SNI',
         sniHelper:
             'Ters vekil arka ucu HTTPS olduğunda, kaynak SNI’yi ayarlamanız gerekebilir. Ayrıntılar için CDN hizmet sağlayıcısının belgelerine bakın.',
+        proxySslVerify: 'Verify Backend SSL Certificate',
+        proxySslVerifyHelper: 'When enabled, the proxy will strictly verify the upstream SSL certificate (disabled by default).',
         huaweicloud: 'Huawei Cloud',
         createDb: 'Veritabanı Oluştur',
         enableSSLHelper: 'Etkinleştirme başarısızlığı web sitesinin oluşturulmasını etkilemez',

--- a/frontend/src/lang/modules/tr.ts
+++ b/frontend/src/lang/modules/tr.ts
@@ -2809,8 +2809,9 @@ const message = {
         sni: 'Kaynak SNI',
         sniHelper:
             'Ters vekil arka ucu HTTPS olduğunda, kaynak SNI’yi ayarlamanız gerekebilir. Ayrıntılar için CDN hizmet sağlayıcısının belgelerine bakın.',
-        proxySslVerify: 'Verify Backend SSL Certificate',
-        proxySslVerifyHelper: 'When enabled, the proxy will strictly verify the upstream SSL certificate (disabled by default).',
+        proxySslVerify: 'Arka uç SSL sertifikasını doğrula',
+        proxySslVerifyHelper:
+            'Etkinleştirildiğinde, vekil sunucu üst akış SSL sertifikasını sıkı biçimde doğrular (varsayılan olarak kapalı).',
         huaweicloud: 'Huawei Cloud',
         createDb: 'Veritabanı Oluştur',
         enableSSLHelper: 'Etkinleştirme başarısızlığı web sitesinin oluşturulmasını etkilemez',

--- a/frontend/src/lang/modules/zh-Hant.ts
+++ b/frontend/src/lang/modules/zh-Hant.ts
@@ -2559,6 +2559,8 @@ const message = {
         website404Helper: '網站 404 錯誤頁僅支援 PHP 執行環境網站和靜態網站',
         sni: '回源 SNI',
         sniHelper: '反代後端為 https 的時候可能需要設定回源 SNI，詳細需要看 CDN 服務商檔案',
+        proxySslVerify: '校驗後端 SSL 憑證',
+        proxySslVerifyHelper: '開啟後，反向代理 HTTPS 後端時將嚴格校驗伺服器憑證（預設不校驗）',
         huaweicloud: '華為雲',
         createDb: '建立資料庫',
         enableSSLHelper: '開啟失敗不會影響網站建立',

--- a/frontend/src/lang/modules/zh.ts
+++ b/frontend/src/lang/modules/zh.ts
@@ -2560,6 +2560,8 @@ const message = {
         website404Helper: '网站 404 错误页仅支持 PHP 运行环境网站和静态网站',
         sni: '回源 SNI',
         sniHelper: '反代后端为 https 的时候可能需要设置回源 SNI，具体需要看 CDN 服务商文档',
+        proxySslVerify: '校验后端 SSL 证书',
+        proxySslVerifyHelper: '开启后，反向代理 HTTPS 后端时将严格校验服务器证书（默认不校验）',
         huaweicloud: '华为云',
         createDb: '创建数据库',
         enableSSLHelper: '开启失败不会影响网站创建',

--- a/frontend/src/views/website/website/config/basic/proxy/create/index.vue
+++ b/frontend/src/views/website/website/config/basic/proxy/create/index.vue
@@ -68,6 +68,14 @@
                         >
                             <el-input v-model.trim="proxy.proxySSLName" />
                         </el-form-item>
+
+                        <div class="flex justify-between items-center py-3">
+                            <div class="flex flex-col gap-1">
+                                <span class="font-medium">{{ $t('website.proxySslVerify') }}</span>
+                                <span class="input-help">{{ $t('website.proxySslVerifyHelper') }}</span>
+                            </div>
+                            <el-switch v-model="proxy.sslVerify" size="large" />
+                        </div>
                     </template>
                 </el-tab-pane>
 
@@ -279,6 +287,7 @@ const initData = (): Website.ProxyConfig => ({
     proxyProtocol: 'http://',
     sni: false,
     proxySSLName: '',
+    sslVerify: false,
     serverCacheTime: 10,
     serverCacheUnit: 'm',
     browserCache: 'noModify',


### PR DESCRIPTION
#### What this PR does / why we need it?
为反向代理新增可配置是否跳过ssl证书校验功能,适配部分需要验证tls的情况

#### Summary of your change
添加proxy_ssl_verify配置相关项和翻译。

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.