### PR TITLE
fix: handle HTML responses in panel management API requests

### DIFF
--- a/core/utils/req_helper/proxy_local/req_to_local.go
+++ b/core/utils/req_helper/proxy_local/req_to_local.go
@@ -62,16 +62,30 @@ func NewLocalClient(reqUrl, reqMethod string, body io.Reader, ctx *gin.Context) 
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("do request failed, err: %v", resp.Status)
-	}
 	bodyByte, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("read resp body from request failed, err: %v", err)
 	}
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, fmt.Errorf("authentication failed: remote panel returned 401 Unauthorized, please check API key or credentials")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("do request failed, status: %s", resp.Status)
+	}
+
+	contentType := resp.Header.Get("Content-Type")
+	if !strings.Contains(contentType, "application/json") && !strings.Contains(contentType, "text/json") {
+		preview := string(bodyByte)
+		if len(preview) > 200 {
+			preview = preview[:200]
+		}
+		return nil, fmt.Errorf("expected JSON response but got Content-Type: %s, body: %s", contentType, preview)
+	}
+
 	var respJson dto.Response
 	if err := json.Unmarshal(bodyByte, &respJson); err != nil {
-		return nil, fmt.Errorf("json umarshal resp data failed, err: %v", err)
+		return nil, fmt.Errorf("json unmarshal resp data failed, err: %v", err)
 	}
 	if respJson.Code != http.StatusOK {
 		return nil, errors.New(strings.ReplaceAll(respJson.Message, i18n.Get("ErrInternalServerKey"), ""))


### PR DESCRIPTION
## Summary

Fixes #12260 - Multi-machine management fails when adding a panel with error:
```
load current config failed, err: json umarshal resp data failed, err: invalid character '<' looking for beginning of value
```

### Root Cause

When the remote panel returns a 401 Unauthorized response, it sends an HTML page (`401.html`) with `Content-Type: text/html`. The code at `core/utils/req_helper/proxy_local/req_to_local.go` attempted to `json.Unmarshal()` this HTML, causing the `invalid character '<'` error.

### Fix

- Add explicit **401 Unauthorized** handling with a clear error message
- **Validate Content-Type** header is JSON before attempting unmarshal
- Include response preview in error messages for easier debugging
- Read body before status check so error messages can include response content

### Changed file
- `core/utils/req_helper/proxy_local/req_to_local.go`

```release-note
fix: Fix multi-machine panel management failing with JSON unmarshal error when remote panel returns HTML response (#12260)
```