### PR TITLE
fix: open container directory at WorkingDir instead of root

### DIFF
--- a/frontend/src/views/container/container/file-browser/index.vue
+++ b/frontend/src/views/container/container/file-browser/index.vue
@@ -141,13 +141,14 @@ const pathSegments = computed(() => {
 interface DrawerProps {
     containerID: string;
     title: string;
+    workingDir?: string;
 }
 
 const acceptParams = async (params: DrawerProps): Promise<void> => {
     visible.value = true;
     containerID.value = params.containerID;
     title.value = params.title;
-    filePath.value = '/';
+    filePath.value = params.workingDir || '/';
     await loadContainerFiles();
 };
 

--- a/frontend/src/views/container/container/index.vue
+++ b/frontend/src/views/container/container/index.vue
@@ -677,9 +677,19 @@ const onTerminal = (row: any) => {
     dialogTerminalRef.value!.acceptParams({ containerID: row.containerID, title: title });
 };
 const dialogFileBrowserRef = ref();
-const onOpenFileBrowser = (row: any) => {
+const onOpenFileBrowser = async (row: any) => {
     const title = i18n.global.t('menu.container') + ' ' + row.name;
-    dialogFileBrowserRef.value!.acceptParams({ containerID: row.containerID, title: title });
+    let workingDir = '/';
+    try {
+        const res = await inspect({ id: row.containerID, type: 'container', detail: '' });
+        const data = typeof res.data === 'string' ? JSON.parse(res.data) : res.data;
+        if (data?.Config?.WorkingDir) {
+            workingDir = data.Config.WorkingDir;
+        }
+    } catch (e) {
+        /* fallback to root */
+    }
+    dialogFileBrowserRef.value!.acceptParams({ containerID: row.containerID, title: title, workingDir: workingDir });
 };
 
 const onInspect = async (row: any) => {


### PR DESCRIPTION
## Summary

Fixes #12255 - Container directory view shows root `/` instead of the container's working directory.

### Changes

When clicking **Directory** on a container, the file browser now:
1. Calls `inspect` API to get the container's `Config.WorkingDir`
2. Opens the file browser at that path (e.g., `/app`, `/var/www`)
3. Falls back to `/` if WorkingDir is not set or inspect fails

### Changed files
- `frontend/src/views/container/container/index.vue` - Fetch WorkingDir via inspect before opening file browser
- `frontend/src/views/container/container/file-browser/index.vue` - Accept optional `workingDir` parameter

```release-note
fix: Container directory view now opens at the container's WorkingDir instead of always starting at root (#12255)
```