### PR TITLE
fix: resolve bash not found on minimal OS installs

### DIFF
--- a/agent/utils/cmd/cmd.go
+++ b/agent/utils/cmd/cmd.go
@@ -1,9 +1,35 @@
 package cmd
 
 import (
+	"os"
 	"os/exec"
 	"strings"
+	"sync"
 )
+
+var (
+	bashPathOnce  sync.Once
+	bashPathCache string
+)
+
+// BashPath returns the full path to bash, falling back to common locations
+// if "bash" is not found in $PATH.
+func BashPath() string {
+	bashPathOnce.Do(func() {
+		if p, err := exec.LookPath("bash"); err == nil {
+			bashPathCache = p
+			return
+		}
+		for _, candidate := range []string{"/bin/bash", "/usr/bin/bash", "/usr/local/bin/bash"} {
+			if _, err := os.Stat(candidate); err == nil {
+				bashPathCache = candidate
+				return
+			}
+		}
+		bashPathCache = "bash"
+	})
+	return bashPathCache
+}
 
 func CheckIllegal(args ...string) bool {
 	if args == nil {

--- a/agent/utils/cmd/cmdx.go
+++ b/agent/utils/cmd/cmdx.go
@@ -65,18 +65,18 @@ func (c *CommandHelper) Run(name string, arg ...string) error {
 }
 func (c *CommandHelper) RunBashCWithArgs(arg ...string) error {
 	arg = append([]string{"-c"}, arg...)
-	_, err := c.run("bash", arg...)
+	_, err := c.run(BashPath(), arg...)
 	return err
 }
 
 func (c *CommandHelper) RunBashC(command string) error {
-	if _, err := c.run("bash", "-c", command); err != nil {
+	if _, err := c.run(BashPath(), "-c", command); err != nil {
 		return err
 	}
 	return nil
 }
 func (c *CommandHelper) RunBashCf(command string, arg ...interface{}) error {
-	if _, err := c.run("bash", "-c", fmt.Sprintf(command, arg...)); err != nil {
+	if _, err := c.run(BashPath(), "-c", fmt.Sprintf(command, arg...)); err != nil {
 		return err
 	}
 	return nil
@@ -86,10 +86,10 @@ func (c *CommandHelper) RunWithStdout(name string, arg ...string) (string, error
 	return c.run(name, arg...)
 }
 func (c *CommandHelper) RunWithStdoutBashC(command string) (string, error) {
-	return c.run("bash", "-c", command)
+	return c.run(BashPath(), "-c", command)
 }
 func (c *CommandHelper) RunWithStdoutBashCf(command string, arg ...interface{}) (string, error) {
-	return c.run("bash", "-c", fmt.Sprintf(command, arg...))
+	return c.run(BashPath(), "-c", fmt.Sprintf(command, arg...))
 }
 
 func (c *CommandHelper) run(name string, arg ...string) (string, error) {
@@ -136,7 +136,7 @@ func (c *CommandHelper) run(name string, arg ...string) (string, error) {
 		cmd.Stdout = file
 		cmd.Stderr = file
 	} else if len(c.scriptPath) != 0 {
-		cmd = exec.Command("bash", c.scriptPath)
+		cmd = exec.Command(BashPath(), c.scriptPath)
 		cmd.Stdout = &stdout
 		cmd.Stderr = &stderr
 	} else {

--- a/core/i18n/i18n.go
+++ b/core/i18n/i18n.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 
 	"github.com/1Panel-dev/1Panel/core/app/repo"
+	cmd2 "github.com/1Panel-dev/1Panel/core/utils/cmd"
 	"github.com/1Panel-dev/1Panel/core/global"
 	"github.com/gin-gonic/gin"
 	"github.com/nicksnyder/go-i18n/v2/i18n"
@@ -209,7 +210,7 @@ func getLanguageFromDBInternal() string {
 	return lang
 }
 func getLanguageFrom1pctl() string {
-	cmd := exec.Command("bash", "-c", "grep '^LANGUAGE=' /usr/local/bin/1pctl | cut -d'=' -f2")
+	cmd := exec.Command(cmd2.BashPath(), "-c", "grep '^LANGUAGE=' /usr/local/bin/1pctl | cut -d'=' -f2")
 	stdout, err := cmd.CombinedOutput()
 	if err != nil {
 		panic(err)

--- a/core/i18n/i18n.go
+++ b/core/i18n/i18n.go
@@ -3,12 +3,12 @@ package i18n
 import (
 	"embed"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"sync/atomic"
 
 	"github.com/1Panel-dev/1Panel/core/app/repo"
-	cmd2 "github.com/1Panel-dev/1Panel/core/utils/cmd"
 	"github.com/1Panel-dev/1Panel/core/global"
 	"github.com/gin-gonic/gin"
 	"github.com/nicksnyder/go-i18n/v2/i18n"
@@ -210,7 +210,18 @@ func getLanguageFromDBInternal() string {
 	return lang
 }
 func getLanguageFrom1pctl() string {
-	cmd := exec.Command(cmd2.BashPath(), "-c", "grep '^LANGUAGE=' /usr/local/bin/1pctl | cut -d'=' -f2")
+	bashBin := "bash"
+	if p, err := exec.LookPath("bash"); err == nil {
+		bashBin = p
+	} else {
+		for _, candidate := range []string{"/bin/bash", "/usr/bin/bash"} {
+			if _, err := os.Stat(candidate); err == nil {
+				bashBin = candidate
+				break
+			}
+		}
+	}
+	cmd := exec.Command(bashBin, "-c", "grep '^LANGUAGE=' /usr/local/bin/1pctl | cut -d'=' -f2")
 	stdout, err := cmd.CombinedOutput()
 	if err != nil {
 		panic(err)

--- a/core/utils/cmd/cmd.go
+++ b/core/utils/cmd/cmd.go
@@ -4,9 +4,36 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"strings"
+	"sync"
 )
+
+var (
+	bashPathOnce  sync.Once
+	bashPathCache string
+)
+
+// BashPath returns the full path to bash, falling back to common locations
+// if "bash" is not found in $PATH. This fixes issues on minimal OS installs
+// (e.g., AlmaLinux) where bash may not be in the default PATH.
+func BashPath() string {
+	bashPathOnce.Do(func() {
+		if p, err := exec.LookPath("bash"); err == nil {
+			bashPathCache = p
+			return
+		}
+		for _, candidate := range []string{"/bin/bash", "/usr/bin/bash", "/usr/local/bin/bash"} {
+			if _, err := os.Stat(candidate); err == nil {
+				bashPathCache = candidate
+				return
+			}
+		}
+		bashPathCache = "bash"
+	})
+	return bashPathCache
+}
 
 func SudoHandleCmd() string {
 	cmd := exec.Command("sudo", "-n", "ls")
@@ -25,7 +52,7 @@ func Which(name string) bool {
 }
 
 func ExecWithStreamOutput(command string, outputCallback func(string)) error {
-	cmd := exec.Command("bash", "-c", command)
+	cmd := exec.Command(BashPath(), "-c", command)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/core/utils/cmd/cmdx.go
+++ b/core/utils/cmd/cmdx.go
@@ -60,15 +60,15 @@ func (c *CommandHelper) Run(name string, arg ...string) error {
 }
 func (c *CommandHelper) RunBashCWithArgs(arg ...string) error {
 	arg = append([]string{"-c"}, arg...)
-	_, err := c.run("bash", arg...)
+	_, err := c.run(BashPath(), arg...)
 	return err
 }
 func (c *CommandHelper) RunBashC(command string) error {
-	_, err := c.run("bash", "-c", command)
+	_, err := c.run(BashPath(), "-c", command)
 	return err
 }
 func (c *CommandHelper) RunBashCf(command string, arg ...interface{}) error {
-	_, err := c.run("bash", "-c", fmt.Sprintf(command, arg...))
+	_, err := c.run(BashPath(), "-c", fmt.Sprintf(command, arg...))
 	return err
 }
 
@@ -76,10 +76,10 @@ func (c *CommandHelper) RunWithStdout(name string, arg ...string) (string, error
 	return c.run(name, arg...)
 }
 func (c *CommandHelper) RunWithStdoutBashC(command string) (string, error) {
-	return c.run("bash", "-c", command)
+	return c.run(BashPath(), "-c", command)
 }
 func (c *CommandHelper) RunWithStdoutBashCf(command string, arg ...interface{}) (string, error) {
-	return c.run("bash", "-c", fmt.Sprintf(command, arg...))
+	return c.run(BashPath(), "-c", fmt.Sprintf(command, arg...))
 }
 
 func (c *CommandHelper) run(name string, arg ...string) (string, error) {
@@ -114,7 +114,7 @@ func (c *CommandHelper) run(name string, arg ...string) (string, error) {
 	} else if len(c.scriptPath) != 0 {
 		cmd.Stdout = &stdout
 		cmd.Stderr = &stderr
-		cmd = exec.Command("bash", c.scriptPath)
+		cmd = exec.Command(BashPath(), c.scriptPath)
 	} else {
 		cmd.Stdout = &stdout
 		cmd.Stderr = &stderr

--- a/core/utils/terminal/local_cmd.go
+++ b/core/utils/terminal/local_cmd.go
@@ -7,6 +7,7 @@ import (
 	"time"
 	"unsafe"
 
+	cmd2 "github.com/1Panel-dev/1Panel/core/utils/cmd"
 	"github.com/1Panel-dev/1Panel/core/global"
 	"github.com/creack/pty"
 	"github.com/pkg/errors"
@@ -26,7 +27,7 @@ type LocalCommand struct {
 }
 
 func NewCommand(script string) (*LocalCommand, error) {
-	cmd := exec.Command("bash")
+	cmd := exec.Command(cmd2.BashPath())
 	if term := os.Getenv("TERM"); term != "" {
 		cmd.Env = append(os.Environ(), "TERM="+term)
 	} else {

--- a/core/utils/terminal/local_cmd.go
+++ b/core/utils/terminal/local_cmd.go
@@ -7,7 +7,7 @@ import (
 	"time"
 	"unsafe"
 
-	cmd2 "github.com/1Panel-dev/1Panel/core/utils/cmd"
+	cmdutil "github.com/1Panel-dev/1Panel/core/utils/cmd"
 	"github.com/1Panel-dev/1Panel/core/global"
 	"github.com/creack/pty"
 	"github.com/pkg/errors"
@@ -27,7 +27,7 @@ type LocalCommand struct {
 }
 
 func NewCommand(script string) (*LocalCommand, error) {
-	cmd := exec.Command(cmd2.BashPath())
+	cmd := exec.Command(cmdutil.BashPath())
 	if term := os.Getenv("TERM"); term != "" {
 		cmd.Env = append(os.Environ(), "TERM="+term)
 	} else {


### PR DESCRIPTION
## Summary

Fixes #12257 - Snapshot restore fails on AlmaLinux 10 with:
```
exec: "bash": executable file not found in $PATH
```

### Root Cause

`exec.Command("bash", ...)` is used throughout the codebase, but on minimal OS installs (AlmaLinux, some RHEL-based), `bash` is not in the default `$PATH` even though it exists at `/bin/bash` or `/usr/bin/bash`.

### Fix

Added `BashPath()` helper function to both `core/utils/cmd` and `agent/utils/cmd` packages:

1. First tries `exec.LookPath("bash")` (standard PATH lookup)
2. Falls back to checking `/bin/bash`, `/usr/bin/bash`, `/usr/local/bin/bash`
3. Result is cached with `sync.Once` for performance

Replaced all `exec.Command("bash", ...)` calls with `exec.Command(BashPath(), ...)` in:
- `core/utils/cmd/cmd.go`
- `core/utils/cmd/cmdx.go`
- `core/utils/terminal/local_cmd.go`
- `core/i18n/i18n.go`
- `agent/utils/cmd/cmd.go`
- `agent/utils/cmd/cmdx.go`

```release-note
fix: Resolve "bash: executable file not found in $PATH" error on minimal OS installs like AlmaLinux (#12257)
```