### PR TITLE
fix: auto-allow firewall port when creating website with non-standard port

### DIFF
--- a/agent/app/service/website.go
+++ b/agent/app/service/website.go
@@ -302,9 +302,15 @@ func (w WebsiteService) CreateWebsite(create request.WebsiteCreate) (err error) 
 			}
 		}
 	} else {
-		domains, _, _, err = getWebsiteDomains(create.Domains, defaultHttpPort, nginxInstall.HttpsPort, 0)
+		var addPorts []int
+		domains, addPorts, _, err = getWebsiteDomains(create.Domains, defaultHttpPort, nginxInstall.HttpsPort, 0)
 		if err != nil {
 			return err
+		}
+		if len(addPorts) > 0 {
+			go func() {
+				_ = OperateFirewallPort(nil, addPorts)
+			}()
 		}
 		primaryDomain = domains[0].Domain
 		if domains[0].Port != defaultHttpPort {


### PR DESCRIPTION
## Summary

Fixes #12233 - Creating a website with a non-standard port does not auto-allow the port in the firewall, but adding a domain with a non-standard port to an existing website does.

### Root Cause

In `agent/app/service/website.go` line 305, `getWebsiteDomains()` returns `addPorts` as the second value, but it was being discarded with `_`:
```go
// Before (line 305):
domains, _, _, err = getWebsiteDomains(...)
```

Meanwhile, `website_domain.go:30-35` correctly captures and uses `addPorts`:
```go
domainModels, addPorts, _, err = getWebsiteDomains(...)
go func() {
    _ = OperateFirewallPort(nil, addPorts)
}()
```

### Fix

Capture `addPorts` and call `OperateFirewallPort()` in `CreateWebsite`, matching the existing pattern in `CreateWebsiteDomain`.

### Changed file
- `agent/app/service/website.go` (+7, -1)

```release-note
fix: Automatically allow firewall access when creating websites with non-standard ports (#12233)
```