### PR TITLE
feat: add remark field to AI agent list

### DIFF
--- a/agent/app/api/v2/agents.go
+++ b/agent/app/api/v2/agents.go
@@ -72,6 +72,26 @@ func (b *BaseApi) DeleteAgent(c *gin.Context) {
 }
 
 // @Tags AI
+// @Summary Update Agent remark
+// @Accept json
+// @Param request body dto.AgentRemarkUpdateReq true "request"
+// @Success 200
+// @Security ApiKeyAuth
+// @Security Timestamp
+// @Router /ai/agents/remark/update [post]
+func (b *BaseApi) UpdateAgentRemark(c *gin.Context) {
+	var req dto.AgentRemarkUpdateReq
+	if err := helper.CheckBindAndValidate(&req, c); err != nil {
+		return
+	}
+	if err := agentService.UpdateRemark(req); err != nil {
+		helper.InternalServer(c, err)
+		return
+	}
+	helper.Success(c)
+}
+
+// @Tags AI
 // @Summary Reset Agent token
 // @Accept json
 // @Param request body dto.AgentTokenResetReq true "request"

--- a/agent/app/dto/agents.go
+++ b/agent/app/dto/agents.go
@@ -50,6 +50,7 @@ type AgentItem struct {
 	Path          string    `json:"path"`
 	ConfigPath    string    `json:"configPath"`
 	Upgradable    bool      `json:"upgradable"`
+	Remark        string    `json:"remark"`
 	CreatedAt     time.Time `json:"createdAt"`
 }
 
@@ -61,6 +62,11 @@ type AgentDeleteReq struct {
 
 type AgentTokenResetReq struct {
 	ID uint `json:"id" validate:"required"`
+}
+
+type AgentRemarkUpdateReq struct {
+	ID     uint   `json:"id" validate:"required"`
+	Remark string `json:"remark"`
 }
 
 type AgentModelConfigUpdateReq struct {

--- a/agent/app/model/agent.go
+++ b/agent/app/model/agent.go
@@ -17,4 +17,5 @@ type Agent struct {
 	AppInstallID  uint   `json:"appInstallId"`
 	AccountID     uint   `json:"accountId"`
 	ConfigPath    string `json:"configPath"`
+	Remark        string `json:"remark"`
 }

--- a/agent/app/service/agents.go
+++ b/agent/app/service/agents.go
@@ -26,6 +26,7 @@ type IAgentService interface {
 	Delete(req dto.AgentDeleteReq) error
 	ResetToken(req dto.AgentTokenResetReq) error
 	UpdateModelConfig(req dto.AgentModelConfigUpdateReq) error
+	UpdateRemark(req dto.AgentRemarkUpdateReq) error
 	GetProviders() ([]dto.ProviderInfo, error)
 	GetSecurityConfig(req dto.AgentSecurityConfigReq) (*dto.AgentSecurityConfig, error)
 	UpdateSecurityConfig(req dto.AgentSecurityConfigUpdateReq) error
@@ -275,6 +276,15 @@ func (a AgentService) Delete(req dto.AgentDeleteReq) error {
 		return err
 	}
 	return nil
+}
+
+func (a AgentService) UpdateRemark(req dto.AgentRemarkUpdateReq) error {
+	agent, err := agentRepo.GetFirst(repo.WithByID(req.ID))
+	if err != nil {
+		return err
+	}
+	agent.Remark = req.Remark
+	return agentRepo.Save(agent)
 }
 
 func (a AgentService) ResetToken(req dto.AgentTokenResetReq) error {

--- a/agent/app/service/agents_utils.go
+++ b/agent/app/service/agents_utils.go
@@ -336,6 +336,7 @@ func buildAgentItem(agent *model.Agent, appInstall *model.AppInstall, envMap map
 		AppInstallID:  agent.AppInstallID,
 		AccountID:     agent.AccountID,
 		ConfigPath:    agent.ConfigPath,
+		Remark:        agent.Remark,
 		CreatedAt:     agent.CreatedAt,
 	}
 	if appInstall != nil && appInstall.ID > 0 {

--- a/agent/init/migration/migrate.go
+++ b/agent/init/migration/migrate.go
@@ -76,6 +76,7 @@ func InitAgentDB() {
 		migrations.InitAgentAccountModelPool,
 		migrations.AddHostTable,
 		migrations.AddAITerminalSettings,
+		migrations.AddAgentRemark,
 	})
 	if err := m.Migrate(); err != nil {
 		global.LOG.Error(err)

--- a/agent/init/migration/migrations/init.go
+++ b/agent/init/migration/migrations/init.go
@@ -1133,3 +1133,10 @@ var AddAITerminalSettings = &gormigrate.Migration{
 		}).Error
 	},
 }
+
+var AddAgentRemark = &gormigrate.Migration{
+	ID: "20260322-add-agent-remark",
+	Migrate: func(tx *gorm.DB) error {
+		return tx.AutoMigrate(&model.Agent{})
+	},
+}

--- a/agent/router/ro_ai.go
+++ b/agent/router/ro_ai.go
@@ -45,6 +45,7 @@ func (a *AIToolsRouter) InitRouter(Router *gin.RouterGroup) {
 		aiToolsRouter.POST("/agents/delete", baseApi.DeleteAgent)
 		aiToolsRouter.POST("/agents/token/reset", baseApi.ResetAgentToken)
 		aiToolsRouter.POST("/agents/model/update", baseApi.UpdateAgentModelConfig)
+		aiToolsRouter.POST("/agents/remark/update", baseApi.UpdateAgentRemark)
 		aiToolsRouter.GET("/agents/providers", baseApi.GetAgentProviders)
 		aiToolsRouter.POST("/agents/accounts", baseApi.CreateAgentAccount)
 		aiToolsRouter.POST("/agents/accounts/update", baseApi.UpdateAgentAccount)

--- a/frontend/src/api/interface/ai.ts
+++ b/frontend/src/api/interface/ai.ts
@@ -284,7 +284,13 @@ export namespace AI {
         path: string;
         configPath: string;
         upgradable: boolean;
+        remark: string;
         createdAt: string;
+    }
+
+    export interface AgentRemarkUpdateReq {
+        id: number;
+        remark: string;
     }
 
     export interface AgentDeleteReq {

--- a/frontend/src/api/modules/ai.ts
+++ b/frontend/src/api/modules/ai.ts
@@ -113,6 +113,10 @@ export const updateAgentModelConfig = (req: AI.AgentModelConfigUpdateReq) => {
     return http.post(`/ai/agents/model/update`, req);
 };
 
+export const updateAgentRemark = (req: AI.AgentRemarkUpdateReq) => {
+    return http.post(`/ai/agents/remark/update`, req);
+};
+
 export const getAgentProviders = () => {
     return http.get<AI.ProviderInfo[]>(`/ai/agents/providers`);
 };

--- a/frontend/src/lang/modules/en.ts
+++ b/frontend/src/lang/modules/en.ts
@@ -127,6 +127,7 @@ const message = {
             operate: 'Actions',
             message: 'Message',
             description: 'Description',
+            remark: 'Remark',
             interval: 'Interval',
             user: 'Owner',
             title: 'Title',

--- a/frontend/src/lang/modules/zh.ts
+++ b/frontend/src/lang/modules/zh.ts
@@ -118,6 +118,7 @@ const message = {
             operate: '操作',
             message: '信息',
             description: '描述',
+            remark: '备注',
             interval: '耗时',
             user: '用户',
             title: '标题',

--- a/frontend/src/views/ai/agents/agent/index.vue
+++ b/frontend/src/views/ai/agents/agent/index.vue
@@ -97,6 +97,16 @@
                             <span v-else>-</span>
                         </template>
                     </el-table-column>
+                    <el-table-column :label="$t('commons.table.remark')" prop="remark" min-width="150">
+                        <template #default="{ row }">
+                            <el-input
+                                v-model="row.remark"
+                                size="small"
+                                :placeholder="$t('commons.table.remark')"
+                                @change="onRemarkChange(row)"
+                            />
+                        </template>
+                    </el-table-column>
                     <el-table-column
                         :label="$t('commons.table.date')"
                         prop="createdAt"
@@ -128,7 +138,7 @@
 <script setup lang="ts">
 import { onMounted, reactive, ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
-import { pageAgents, resetAgentToken } from '@/api/modules/ai';
+import { pageAgents, resetAgentToken, updateAgentRemark } from '@/api/modules/ai';
 import { installedOp, searchApp, searchAppInstalled } from '@/api/modules/app';
 import { AI } from '@/api/interface/ai';
 import { App } from '@/api/interface/app';
@@ -348,6 +358,14 @@ const jumpWebUI = (row: AI.AgentItem) => {
 
 const onDelete = (row: AI.AgentItem) => {
     deleteRef.value?.acceptParams(row.id, row.name);
+};
+
+const onRemarkChange = async (row: AI.AgentItem) => {
+    try {
+        await updateAgentRemark({ id: row.id, remark: row.remark });
+    } catch (e) {
+        /* silent */
+    }
 };
 
 const onResetToken = async (row: AI.AgentItem) => {


### PR DESCRIPTION
## Summary

Closes #12191 - Add a remark/note field to the AI agent list so users can annotate what each agent is for.

### Changes

Full stack implementation:

| Layer | File | Change |
|-------|------|--------|
| Model | `agent/app/model/agent.go` | Add `Remark` field |
| DTO | `agent/app/dto/agents.go` | Add `AgentRemarkUpdateReq`, `Remark` to `AgentItem` |
| Service | `agent/app/service/agents.go` | Add `UpdateRemark()` method |
| Utils | `agent/app/service/agents_utils.go` | Map `Remark` in `buildAgentItem()` |
| API | `agent/app/api/v2/agents.go` | Add `UpdateAgentRemark` handler |
| Router | `agent/router/ro_ai.go` | Add `POST /ai/agents/remark/update` |
| Migration | `agent/init/migration/` | Auto-migrate for new column |
| Frontend | `frontend/src/views/ai/agents/agent/index.vue` | Inline editable remark column |
| Frontend API | `frontend/src/api/modules/ai.ts` | Add `updateAgentRemark()` |
| i18n | `en.ts`, `zh.ts` | Add `commons.table.remark` key |

The remark column uses an inline `el-input` that auto-saves on change.

```release-note
feat: Add remark/note field to AI agent list for easier identification (#12191)
```