### PR TITLE
fix: code editor tab persistence and close behavior

### DIFF
--- a/frontend/src/views/host/file-management/code-editor/index.vue
+++ b/frontend/src/views/host/file-management/code-editor/index.vue
@@ -568,18 +568,25 @@ const removeTab = (targetPath: TabPaneName) => {
             .then(() => {
                 updateTabs();
                 saveContent();
-                getContent(selectTab.value, '');
+                saveTabsToStorage();
+                if (fileTabs.value.length > 0) {
+                    getContent(selectTab.value, '');
+                }
             })
             .catch(() => {
                 updateTabs();
                 isEdit.value = false;
+                saveTabsToStorage();
                 if (fileTabs.value.length > 0) {
                     getContent(selectTab.value, '');
                 }
             });
     } else {
         updateTabs();
-        getContent(selectTab.value, '');
+        saveTabsToStorage();
+        if (fileTabs.value.length > 0) {
+            getContent(selectTab.value, '');
+        }
     }
 };
 
@@ -613,6 +620,7 @@ const removeAllTab = (targetPath: string, type: 'left' | 'right' | 'all') => {
     const onConfirm = () => {
         updateTabs();
         saveContent();
+        saveTabsToStorage();
     };
 
     const onCancel = () => {
@@ -622,6 +630,7 @@ const removeAllTab = (targetPath: string, type: 'left' | 'right' | 'all') => {
         isEdit.value = false;
         isCreate.value = 'none';
         updateTabs();
+        saveTabsToStorage();
     };
 
     if (isEdit.value) {
@@ -635,6 +644,7 @@ const removeAllTab = (targetPath: string, type: 'left' | 'right' | 'all') => {
             .catch(onCancel);
     } else {
         updateTabs();
+        saveTabsToStorage();
         if (type === 'all') editor.dispose();
         else getContent(activeName, '');
     }

--- a/frontend/src/views/host/file-management/code-editor/tabs/index.vue
+++ b/frontend/src/views/host/file-management/code-editor/tabs/index.vue
@@ -2,17 +2,14 @@
     <el-tabs
         v-model="currentTab"
         type="card"
-        :closable="props.fileTabs.length > 1"
+        :closable="props.fileTabs.length >= 1"
         class="monaco-editor monaco-editor-background"
         @tab-remove="props.onRemoveTab"
         @tab-change="props.onChangeTab"
     >
         <el-tab-pane v-for="item in props.fileTabs" :key="item.path" :name="item.path">
             <template #label>
-                <el-tooltip v-if="props.fileTabs.length == 1" :content="item.path" placement="bottom-start">
-                    <span>{{ item.name }}</span>
-                </el-tooltip>
-                <template v-if="props.fileTabs.length > 1">
+                <template v-if="props.fileTabs.length >= 1">
                     <el-dropdown
                         size="small"
                         :id="item.path"
@@ -58,7 +55,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, watch } from 'vue';
 
 interface FileTabs {
     path: string;


### PR DESCRIPTION
## Summary

Fixes #12098 - Three bugs in the file management code editor tabs.

### Bug 1: Closed tabs reopen next time
`removeTab()` and `removeAllTab()` modified `fileTabs.value` but never called `saveTabsToStorage()`, so the removal was never persisted to localStorage.

**Fix:** Added `saveTabsToStorage()` calls after every tab removal path (save+close, discard+close, direct close).

### Bug 2: Last tab can't be closed
`:closable` was conditioned on `fileTabs.length > 1`, and the context menu (Close All, etc.) was hidden for single tabs.

**Fix:** Changed to `>= 1` so the close button and context menu are always available.

### Bug 3: Missing `watch` import
`watch` was used in `tabs/index.vue` but not imported from Vue, causing tab selection sync issues.

### Changed files
- `frontend/src/views/host/file-management/code-editor/index.vue` - Persist tab removal to localStorage
- `frontend/src/views/host/file-management/code-editor/tabs/index.vue` - Allow closing last tab, fix watch import

```release-note
fix: Code editor tabs now properly persist when closed, last tab can be closed, and "Close All" is always available (#12098)
```