### PR TITLE
feat: allow stopping apps while in restarting state

### DIFF
--- a/frontend/src/views/app-store/installed/index.vue
+++ b/frontend/src/views/app-store/installed/index.vue
@@ -365,7 +365,7 @@ const buttons = [
         },
         disabled: (row: any) => {
             return (
-                row.status !== 'Running' ||
+                (row.status !== 'Running' && row.status !== 'ReStarting') ||
                 row.status === 'DownloadErr' ||
                 row.status === 'Upgrading' ||
                 row.status === 'Rebuilding' ||


### PR DESCRIPTION
## Summary

Closes #12061 - Apps stuck in a restart loop cannot be stopped.

### Root Cause

The Stop button `disabled` condition only allowed `status === 'Running'`:
```js
row.status !== 'Running'  // disables Stop for ALL non-Running states
```

This means apps in `ReStarting` status (e.g., DB connection failed, bad config) have Stop disabled, trapping users.

### Fix

Allow Stop for `ReStarting` status too:
```js
row.status !== 'Running' && row.status !== 'ReStarting'
```

### Changed file
- `frontend/src/views/app-store/installed/index.vue` (+1, -1)

```release-note
feat: Allow stopping apps that are stuck in a restarting loop (#12061)
```