### PR TITLE
fix: hide Install button for already installed apps on dashboard

### DIFF
--- a/frontend/src/views/home/app/index.vue
+++ b/frontend/src/views/home/app/index.vue
@@ -156,17 +156,28 @@
                                     </div>
                                 </div>
                             </el-col>
-                            <el-col :span="1">
+                            <el-col :span="1" v-if="!app.detail || app.detail.length === 0">
                                 <el-button
                                     class="h-app-button"
                                     type="primary"
                                     plain
                                     round
                                     size="small"
-                                    :disabled="app.limit == 1 && app.detail && app.detail.length !== 0"
                                     @click="goInstall(app.key, app.appType)"
                                 >
                                     {{ $t('commons.button.install') }}
+                                </el-button>
+                            </el-col>
+                            <el-col :span="1" v-else-if="app.limit !== 1">
+                                <el-button
+                                    class="h-app-button"
+                                    type="primary"
+                                    plain
+                                    round
+                                    size="small"
+                                    @click="goInstall(app.key, app.appType)"
+                                >
+                                    <el-icon><Plus /></el-icon>
                                 </el-button>
                             </el-col>
                         </el-row>


### PR DESCRIPTION
## Summary

Fixes #11591 - Dashboard shows "Install" button for apps that are already installed.

### Before
The Install button was always visible, just `disabled` when `limit == 1 && detail.length > 0`. This confused users into thinking the app wasn't installed.

### After
| State | Button |
|-------|--------|
| Not installed | "Install" button shown |
| Installed, multi-instance app (`limit != 1`) | Small "+" button for additional instance |
| Installed, single-instance app (`limit == 1`) | No button (already installed) |

### Changed file
- `frontend/src/views/home/app/index.vue` (+13, -2)

```release-note
fix: Hide Install button for already installed apps on the dashboard (#11591)
```