### PR TITLE
fix: increase SSH connection timeout from 5s to 15s for child nodes

### DIFF
--- a/agent/utils/ssh/ssh.go
+++ b/agent/utils/ssh/ssh.go
@@ -40,7 +40,7 @@ func NewClient(c ConnInfo) (*SSHClient, error) {
 		config.Auth = []gossh.AuthMethod{gossh.PublicKeys(signer)}
 	}
 	if c.DialTimeOut == 0 {
-		c.DialTimeOut = 5 * time.Second
+		c.DialTimeOut = 15 * time.Second
 	}
 	config.Timeout = c.DialTimeOut
 

--- a/core/utils/ssh/ssh.go
+++ b/core/utils/ssh/ssh.go
@@ -48,7 +48,7 @@ func NewClient(c ConnInfo) (*SSHClient, error) {
 		config.Auth = []gossh.AuthMethod{gossh.PublicKeys(signer)}
 	}
 	if c.DialTimeOut == 0 {
-		c.DialTimeOut = 5 * time.Second
+		c.DialTimeOut = 15 * time.Second
 	}
 	config.Timeout = c.DialTimeOut
 
@@ -256,7 +256,7 @@ func DialWithTimeout(network, addr string, useProxy bool, config *gossh.ClientCo
 	if err != nil {
 		return nil, err
 	}
-	_ = conn.SetDeadline(time.Now().Add(config.Timeout))
+	_ = conn.SetDeadline(time.Now().Add(config.Timeout * 2))
 	c, chans, reqs, err := gossh.NewClientConn(conn, addr, config)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Fixes #11621 - Child node SSH connection fails with "ssh: handshake failed: i/o timeout" when network latency is high (e.g., domestic China to overseas servers).

### Root Cause

Default `DialTimeOut` was hardcoded to **5 seconds** at `core/utils/ssh/ssh.go:51` and `agent/utils/ssh/ssh.go:43`. For cross-border connections with several seconds of latency, this wasn't enough for both TCP dial + SSH handshake.

Additionally, `DialWithTimeout` set the handshake deadline equal to the dial timeout (`conn.SetDeadline(time.Now().Add(config.Timeout))`), which meant the SSH handshake had to complete in the same window as the dial.

### Fix

- Increase default `DialTimeOut` from **5s to 15s** (both core and agent)
- Set handshake deadline to **2x the timeout** (`config.Timeout * 2`) to give more time for the SSH key exchange after TCP connection

### Changed files
- `core/utils/ssh/ssh.go` - Default timeout 5s → 15s, handshake deadline × 2
- `agent/utils/ssh/ssh.go` - Default timeout 5s → 15s

```release-note
fix: Increase SSH connection timeout from 5s to 15s for better child node connectivity (#11621)
```