### PR TITLE
fix: monitor time-based search timezone offset

### DIFF
--- a/agent/app/service/monitor.go
+++ b/agent/app/service/monitor.go
@@ -58,8 +58,14 @@ func NewIMonitorService() IMonitorService {
 
 func (m *MonitorService) LoadMonitorData(req dto.MonitorSearch) ([]dto.MonitorData, error) {
 	loc, _ := time.LoadLocation(common.LoadTimeZoneByCmd())
-	req.StartTime = req.StartTime.In(loc)
-	req.EndTime = req.EndTime.In(loc)
+	if req.StartTime.Location() == time.UTC && loc != time.UTC {
+		req.StartTime = time.Date(req.StartTime.Year(), req.StartTime.Month(), req.StartTime.Day(),
+			req.StartTime.Hour(), req.StartTime.Minute(), req.StartTime.Second(), req.StartTime.Nanosecond(), loc)
+	}
+	if req.EndTime.Location() == time.UTC && loc != time.UTC {
+		req.EndTime = time.Date(req.EndTime.Year(), req.EndTime.Month(), req.EndTime.Day(),
+			req.EndTime.Hour(), req.EndTime.Minute(), req.EndTime.Second(), req.EndTime.Nanosecond(), loc)
+	}
 
 	var data []dto.MonitorData
 	if req.Param == "all" || req.Param == "cpu" || req.Param == "memory" || req.Param == "load" {
@@ -182,8 +188,14 @@ func (m *MonitorService) LoadGPUOptions() dto.MonitorGPUOptions {
 
 func (m *MonitorService) LoadGPUMonitorData(req dto.MonitorGPUSearch) (dto.MonitorGPUData, error) {
 	loc, _ := time.LoadLocation(common.LoadTimeZoneByCmd())
-	req.StartTime = req.StartTime.In(loc)
-	req.EndTime = req.EndTime.In(loc)
+	if req.StartTime.Location() == time.UTC && loc != time.UTC {
+		req.StartTime = time.Date(req.StartTime.Year(), req.StartTime.Month(), req.StartTime.Day(),
+			req.StartTime.Hour(), req.StartTime.Minute(), req.StartTime.Second(), req.StartTime.Nanosecond(), loc)
+	}
+	if req.EndTime.Location() == time.UTC && loc != time.UTC {
+		req.EndTime = time.Date(req.EndTime.Year(), req.EndTime.Month(), req.EndTime.Day(),
+			req.EndTime.Hour(), req.EndTime.Minute(), req.EndTime.Second(), req.EndTime.Nanosecond(), loc)
+	}
 	var data dto.MonitorGPUData
 	gpuList, err := monitorRepo.GetGPU(repo.WithByCreatedAt(req.StartTime, req.EndTime), monitorRepo.WithByProductName(req.ProductName))
 	if err != nil {


### PR DESCRIPTION
## Summary

Fixes #11891 - Monitor time-based search is off by timezone offset (e.g., 8 hours for UTC+8 servers).

### Root Cause

In `agent/app/service/monitor.go`, `LoadMonitorData` and `LoadGPUMonitorData` used:
```go
req.StartTime = req.StartTime.In(loc)
```

`time.In(loc)` only changes the timezone label for display - it does NOT change the underlying moment in time. So the DB query still searched for the wrong time range.

### Fix

When the frontend sends time in UTC but the server runs in a different timezone, reconstruct the `time.Time` with the server's local timezone. This treats the time values as "wall clock time":

```go
if req.StartTime.Location() == time.UTC && loc != time.UTC {
    req.StartTime = time.Date(year, month, day, hour, min, sec, nsec, loc)
}
```

This shifts the actual moment to match what the user selected in the UI.

### Changed file
- `agent/app/service/monitor.go` - Fix both `LoadMonitorData` and `LoadGPUMonitorData`

```release-note
fix: Monitor time-based search now correctly handles timezone offset (#11891)
```