### PR TITLE
fix: container backup should not fail entirely on mount copy errors

### DIFF
--- a/agent/app/service/backup_container.go
+++ b/agent/app/service/backup_container.go
@@ -442,11 +442,19 @@ func stepBackupContainerMounts(backupCtx *containerBackupContext) error {
 			}
 			if sourceInfo.IsDir() {
 				if err := backupCtx.fileOp.CopyDirWithNewName(item.Source, dataDir, "."); err != nil {
-					return err
+					mountMeta.Status = "failed"
+					mountMeta.Message = fmt.Sprintf("copy dir failed: %v", err)
+					backupCtx.meta.Mounts = append(backupCtx.meta.Mounts, mountMeta)
+					global.LOG.Errorf("container backup: skip mount %s, copy dir failed: %v", item.Source, err)
+					continue
 				}
 			} else {
 				if err := backupCtx.fileOp.CopyFile(item.Source, dataDir); err != nil {
-					return err
+					mountMeta.Status = "failed"
+					mountMeta.Message = fmt.Sprintf("copy file failed: %v", err)
+					backupCtx.meta.Mounts = append(backupCtx.meta.Mounts, mountMeta)
+					global.LOG.Errorf("container backup: skip mount %s, copy file failed: %v", item.Source, err)
+					continue
 				}
 			}
 


### PR DESCRIPTION
## Summary

Fixes #12236 - Container backup fails and gets stuck in "running" state when a mounted directory is too large or disk runs out of space.

### Root Cause

In `stepBackupContainerMounts()`, when `CopyDirWithNewName` or `CopyFile` fails for any mount, the function returns the error immediately, causing the entire backup task to fail. With large bind mounts, this is common (disk full, permissions, etc.).

### Fix

Mount copy failures are now **non-fatal**:
- Error is logged via `global.LOG.Errorf`
- Mount metadata records `status: "failed"` with the error message
- Backup **continues** with remaining mounts
- Task completes successfully with partial backup data

Before:
```go
if err := backupCtx.fileOp.CopyDirWithNewName(...); err != nil {
    return err  // entire backup fails
}
```

After:
```go
if err := backupCtx.fileOp.CopyDirWithNewName(...); err != nil {
    mountMeta.Status = "failed"
    mountMeta.Message = fmt.Sprintf("copy dir failed: %v", err)
    // ... log and continue
    continue
}
```

### Changed file
- `agent/app/service/backup_container.go` (+10, -2)

```release-note
fix: Container backup no longer fails entirely when a mounted directory copy fails (#12236)
```