### PR TITLE
feat: enable IPv6 on 1panel-network by default

### DIFF
--- a/agent/utils/docker/docker.go
+++ b/agent/utils/docker/docker.go
@@ -104,9 +104,16 @@ func (c Client) ListAllContainers() ([]container.Summary, error) {
 }
 
 func (c Client) CreateNetwork(name string) error {
+	enableIPv6 := true
 	_, err := c.cli.NetworkCreate(context.Background(), name, network.CreateOptions{
 		Driver:     "bridge",
-		EnableIPv6: new(bool),
+		EnableIPv6: &enableIPv6,
+		IPAM: &network.IPAM{
+			Config: []network.IPAMConfig{
+				{Subnet: "172.18.0.0/16", Gateway: "172.18.0.1"},
+				{Subnet: "fd00:1panel::/64", Gateway: "fd00:1panel::1"},
+			},
+		},
 	})
 	return err
 }


### PR DESCRIPTION
## Summary

Closes #12202 - Enable IPv6 dual-stack on `1panel-network` by default.

### Before
```go
EnableIPv6: new(bool)  // pointer to false - IPv6 explicitly disabled
```

### After
```go
EnableIPv6: &enableIPv6  // true
IPAM: {
    Config: [
        {Subnet: "172.18.0.0/16", Gateway: "172.18.0.1"},       // IPv4
        {Subnet: "fd00:1panel::/64", Gateway: "fd00:1panel::1"}, // IPv6 ULA
    ]
}
```

Uses ULA (Unique Local Address) range `fd00:1panel::/64` - no public IPv6 required, works for internal container networking.

**Note:** Only affects new installations or networks created after this change. Existing users need to recreate the network manually.

### Changed file
- `agent/utils/docker/docker.go` (+8, -1)

```release-note
feat: Enable IPv6 dual-stack support on 1panel-network by default (#12202)
```