### PR TITLE
fix: auto theme does not update when OS switches day/night mode

### DIFF
--- a/frontend/src/global/use-theme.ts
+++ b/frontend/src/global/use-theme.ts
@@ -1,3 +1,4 @@
+import { onUnmounted } from 'vue';
 import { GlobalStore } from '@/store';
 import { setPrimaryColor } from '@/utils/theme';
 
@@ -25,6 +26,19 @@ export const useTheme = () => {
             }
         }
     };
+
+    // Listen for OS theme changes when theme is set to "auto"
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const onSystemThemeChange = () => {
+        const globalStore = GlobalStore();
+        if (globalStore.themeConfig.theme === 'auto') {
+            switchTheme();
+        }
+    };
+    mediaQuery.addEventListener('change', onSystemThemeChange);
+    onUnmounted(() => {
+        mediaQuery.removeEventListener('change', onSystemThemeChange);
+    });
 
     return {
         switchTheme,


### PR DESCRIPTION
## Summary

Fixes #6813 (point 1) - When theme is set to "auto" (follow system), the panel doesn't switch between dark/light mode when the OS changes without a page reload.

### Root Cause

`useTheme()` in `frontend/src/global/use-theme.ts` only evaluates `window.matchMedia('(prefers-color-scheme: dark)').matches` when `switchTheme()` is explicitly called. No listener is registered for the `change` event on the media query.

### Fix

Added `matchMedia.addEventListener('change', ...)` that calls `switchTheme()` when the OS color scheme changes, but only when the theme setting is `"auto"`. Listener is cleaned up via `onUnmounted`.

### Changed file
- `frontend/src/global/use-theme.ts` (+14)

```release-note
fix: Auto theme now reactively switches when OS changes between light and dark mode (#6813)
```