### PR TITLE
fix: sidebar height inconsistency and favorites tooltip overlap

### DIFF
--- a/frontend/src/layout/components/Sidebar/index.scss
+++ b/frontend/src/layout/components/Sidebar/index.scss
@@ -38,6 +38,7 @@
         }
     }
     .el-sub-menu {
+        margin: 7px 0;
         &.is-active {
             .el-sub-menu__title {
                 span {
@@ -52,7 +53,7 @@
         .el-sub-menu__title {
             background-color: var(--el-menu-item-bg-color);
             box-shadow: 0 0 4px rgba(0, 94, 235, 0.1);
-            margin-top: 7px;
+            margin: 0;
             height: 42px;
             line-height: 42px;
             border-radius: 4px;

--- a/frontend/src/views/host/file-management/index.vue
+++ b/frontend/src/views/host/file-management/index.vue
@@ -279,7 +279,7 @@
                                                             class="box-item"
                                                             effect="dark"
                                                             :content="row.path"
-                                                            placement="top"
+                                                            placement="right"
                                                         >
                                                             <span
                                                                 class="table-link text-ellipsis"


### PR DESCRIPTION
## Summary

Two UI fixes in one PR:

### 1. Sidebar items have different heights (#12247)

Dropdown menu items (el-sub-menu) were taller than regular items because `.el-sub-menu__title` had `margin-top: 7px` while the outer `.el-sub-menu` had no margin. Regular `.el-menu-item` had `margin: 7px 0`.

**Fix:** Move margin to `.el-sub-menu` wrapper (`margin: 7px 0`), reset `__title` margin to 0.

### 2. File favorites tooltip blocks other items (#11922)

The full-path tooltip on favorites used `placement="top"`, causing it to overlap adjacent items in the popover when scrolling past.

**Fix:** Changed to `placement="right"` so tooltips appear beside the item.

### Changed files
- `frontend/src/layout/components/Sidebar/index.scss` - Normalize sub-menu margins
- `frontend/src/views/host/file-management/index.vue` - Tooltip placement top→right

```release-note
fix: Normalize sidebar menu item heights and fix favorites tooltip overlap (#12247, #11922)
```