### PR TITLE
fix: traffic chart spike after page blur and terminal scroll speed

### DIFF
--- a/frontend/src/components/terminal/index.vue
+++ b/frontend/src/components/terminal/index.vue
@@ -110,7 +110,7 @@ const newTerm = () => {
         cursorBlink: terminalStore.cursorBlink ? String(terminalStore.cursorBlink).toLowerCase() === 'enable' : true,
         cursorStyle: terminalStore.cursorStyle ? getStyle() : 'underline',
         scrollback: terminalStore.scrollback || 1000,
-        scrollSensitivity: terminalStore.scrollSensitivity || 15,
+        scrollSensitivity: terminalStore.scrollSensitivity ?? 5,
     });
 };
 

--- a/frontend/src/store/modules/terminal.ts
+++ b/frontend/src/store/modules/terminal.ts
@@ -14,7 +14,7 @@ export const TerminalStore = defineStore({
         cursorBlink: 'enable',
         cursorStyle: 'underline',
         scrollback: 1000,
-        scrollSensitivity: 10,
+        scrollSensitivity: 5,
     }),
     actions: {
         setLineHeight(lineHeight: number) {

--- a/frontend/src/views/home/index.vue
+++ b/frontend/src/views/home/index.vue
@@ -747,6 +747,11 @@ const onLoadCurrentInfo = async () => {
     currentInfo.value.timeSinceUptime = res.data.timeSinceUptime;
 
     let timeInterval = Number(res.data.uptime - currentInfo.value.uptime) || 3;
+    if (skipNextChart.value || timeInterval > 10) {
+        skipNextChart.value = false;
+        currentInfo.value = res.data;
+        return;
+    }
     currentChartInfo.netBytesSent =
         res.data.netBytesSent - currentInfo.value.netBytesSent > 0
             ? Number(((res.data.netBytesSent - currentInfo.value.netBytesSent) / 1024 / timeInterval).toFixed(2))
@@ -982,7 +987,11 @@ const loadSource = (row: any) => {
     );
 };
 
+const skipNextChart = ref(false);
 const onFocus = () => {
+    if (!isActive.value) {
+        skipNextChart.value = true;
+    }
     isActive.value = true;
 };
 const onBlur = () => {

--- a/frontend/src/views/terminal/setting/index.vue
+++ b/frontend/src/views/terminal/setting/index.vue
@@ -363,7 +363,7 @@ const iniTerm = () => {
         cursorBlink: true,
         cursorStyle: 'block',
         scrollback: 1000,
-        scrollSensitivity: 15,
+        scrollSensitivity: 5,
     });
     term.value.open(terminalElement.value);
     applyPreviewBackground();
@@ -415,7 +415,7 @@ const onSetDefault = () => {
     form.cursorBlink = 'Enable';
     form.cursorStyle = 'block';
     form.scrollback = 1000;
-    form.scrollSensitivity = 6;
+    form.scrollSensitivity = 5;
 
     changeItem();
 };


### PR DESCRIPTION
## Summary

Two bug fixes:

### 1. Traffic chart spike after page blur (#12067)

When switching to another tab, polling pauses. On return, accumulated network bytes create a massive spike in the chart.

**Fix:** Skip the first chart data point after resuming from blur (detected by `skipNextChart` flag or `timeInterval > 10s`). Only updates the raw counters without pushing to the chart arrays.

### 2. Terminal mouse wheel scrolls too fast (#11911)

`scrollSensitivity` had 4 different default values across the codebase:

| Location | Old Value |
|----------|-----------|
| Store default | 10 |
| Component fallback | 15 |
| Settings preview | 15 |
| Reset to defaults | 6 |

**Fix:** Unified all to **5** and changed `||` to `??` so that setting 0 (the minimum) is properly respected.

### Changed files
- `frontend/src/views/home/index.vue` - Skip chart update after blur
- `frontend/src/components/terminal/index.vue` - Fix fallback value
- `frontend/src/store/modules/terminal.ts` - Fix store default
- `frontend/src/views/terminal/setting/index.vue` - Fix preview and reset defaults

```release-note
fix: Traffic chart no longer spikes after switching tabs; terminal scroll sensitivity unified to consistent default (#12067, #11911)
```