### PR TITLE
feat: add compose backup scheduled task type

### DIFF
--- a/agent/app/service/cronjob_backup.go
+++ b/agent/app/service/cronjob_backup.go
@@ -357,6 +357,82 @@ func (u *CronjobService) handleSnapshot(cronjob model.Cronjob, jobRecord model.J
 	return nil
 }
 
+func (u *CronjobService) handleCompose(cronjob model.Cronjob, startTime time.Time, taskItem *task.Task) error {
+	composeNames := loadComposesForJob(cronjob)
+	if len(composeNames) == 0 {
+		addSkipTask("Compose", taskItem)
+		return nil
+	}
+	accountMap := NewBackupClientMap(strings.Split(cronjob.SourceAccountIDs, ","))
+	if !accountMap[fmt.Sprintf("%d", cronjob.DownloadAccountID)].isOk {
+		return buserr.New(i18n.GetMsgWithDetail("LoadBackupFailed", accountMap[fmt.Sprintf("%d", cronjob.DownloadAccountID)].message))
+	}
+	for _, composeName := range composeNames {
+		retry := 0
+		taskItem.AddSubTaskWithOps(task.GetTaskName(composeName, task.TaskBackup, task.TaskScopeCronjob), func(t *task.Task) error {
+			var record model.BackupRecord
+			record.Status = constant.StatusSuccess
+			record.From = "cronjob"
+			record.Type = "compose"
+			record.CronjobID = cronjob.ID
+			record.Name = composeName
+			record.DetailName = composeName
+			record.DownloadAccountID, record.SourceAccountIDs = cronjob.DownloadAccountID, cronjob.SourceAccountIDs
+			backupDir := path.Join(global.Dir.LocalBackupDir, fmt.Sprintf("tmp/compose/%s", composeName))
+			record.FileName = simplifiedFileName(fmt.Sprintf("compose_%s_%s.tar.gz", composeName, startTime.Format(constant.DateTimeSlimLayout)+common.RandStrAndNum(5)))
+
+			req := dto.CommonBackup{
+				Type: "compose",
+				Name: composeName,
+			}
+			if err := handleComposeBackup(req, t, 0, backupDir, record.FileName); err != nil {
+				if retry < int(cronjob.RetryTimes) || !cronjob.IgnoreErr {
+					retry++
+					return err
+				} else {
+					t.Log(i18n.GetMsgWithDetail("IgnoreBackupErr", err.Error()))
+					cleanAccountMap(accountMap)
+					return nil
+				}
+			}
+			src := path.Join(backupDir, record.FileName)
+			dst := strings.TrimPrefix(src, global.Dir.LocalBackupDir+"/tmp/")
+			if err := uploadWithMap(*t, accountMap, src, dst, cronjob.SourceAccountIDs, cronjob.DownloadAccountID, cronjob.RetryTimes); err != nil {
+				if retry < int(cronjob.RetryTimes) || !cronjob.IgnoreErr {
+					retry++
+					return err
+				}
+				t.Log(i18n.GetMsgWithDetail("IgnoreUploadErr", err.Error()))
+				cleanAccountMap(accountMap)
+				return nil
+			}
+			record.FileDir = path.Dir(dst)
+			if err := backupRepo.CreateRecord(&record); err != nil {
+				global.LOG.Errorf("save compose backup record failed, err: %v", err)
+				return err
+			}
+			u.removeExpiredBackup(cronjob, accountMap, record)
+			cleanAccountMap(accountMap)
+			return nil
+		}, nil, int(cronjob.RetryTimes), time.Duration(cronjob.Timeout)*time.Second)
+	}
+	return nil
+}
+
+func loadComposesForJob(cronjob model.Cronjob) []string {
+	if cronjob.AppID == "all" {
+		records, _ := composeRepo.ListRecord()
+		var names []string
+		for _, record := range records {
+			if record.Name != "" {
+				names = append(names, record.Name)
+			}
+		}
+		return names
+	}
+	return strings.Split(cronjob.AppID, ",")
+}
+
 func loadAppsForJob(cronjob model.Cronjob) []model.AppInstall {
 	var apps []model.AppInstall
 	if cronjob.AppID == "all" {

--- a/agent/app/service/cronjob_helper.go
+++ b/agent/app/service/cronjob_helper.go
@@ -131,6 +131,8 @@ func (u *CronjobService) loadTask(cronjob *model.Cronjob, record *model.JobRecor
 		err = u.handleDirectory(*cronjob, record.StartTime, taskItem)
 	case "log":
 		err = u.handleSystemLog(*cronjob, record.StartTime, taskItem)
+	case "compose":
+		err = u.handleCompose(*cronjob, record.StartTime, taskItem)
 	case "syncIpGroup":
 		u.handleSyncIpGroup(*cronjob, taskItem)
 	case "cleanLog":
@@ -479,7 +481,7 @@ func (u *CronjobService) removeExpiredLog(cronjob model.Cronjob) {
 }
 
 func hasBackup(cronjobType string) bool {
-	return cronjobType == "app" || cronjobType == "database" || cronjobType == "website" || cronjobType == "directory" || cronjobType == "snapshot" || cronjobType == "log" || cronjobType == "cutWebsiteLog"
+	return cronjobType == "app" || cronjobType == "database" || cronjobType == "website" || cronjobType == "directory" || cronjobType == "snapshot" || cronjobType == "log" || cronjobType == "cutWebsiteLog" || cronjobType == "compose"
 }
 
 func handleCronJobAlert(cronjob *model.Cronjob) {

--- a/frontend/src/lang/modules/en.ts
+++ b/frontend/src/lang/modules/en.ts
@@ -1277,6 +1277,7 @@ const message = {
         cutWebsiteLog: 'Website log rotation',
         cutWebsiteLogHelper: 'The rotated log files will be backed up to the backup directory of 1Panel.',
         syncIpGroup: 'Sync WAF IP groups',
+        compose: 'Backup compose',
         requestExpirationTime: 'Upload request expiration time(Hours)',
         unitHours: 'Unit: Hours',
         alertTitle: 'Planned Task - {0} 「{1}」 Task Failure Alert',

--- a/frontend/src/lang/modules/zh.ts
+++ b/frontend/src/lang/modules/zh.ts
@@ -1220,6 +1220,7 @@ const message = {
         cutWebsiteLog: '切割网站日志',
         cutWebsiteLogHelper: '切割的日志文件会备份到 1Panel 的 backup 目录下',
         syncIpGroup: '同步 WAF IP 组',
+        compose: '备份容器编排',
 
         requestExpirationTime: '上传请求过期时间（小时）',
         unitHours: '单位：小时',

--- a/frontend/src/views/cronjob/cronjob/helper.ts
+++ b/frontend/src/views/cronjob/cronjob/helper.ts
@@ -56,6 +56,7 @@ export function loadDefaultSpec(type: string) {
             break;
         case 'app':
         case 'database':
+        case 'compose':
             item.specType = 'perDay';
             item.hour = 2;
             item.minute = 30;
@@ -84,6 +85,7 @@ export function loadDefaultSpecCustom(type: string) {
             return '30 1 * * 1';
         case 'app':
         case 'database':
+        case 'compose':
             return '30 2 * * *';
         case 'directory':
         case 'cutWebsiteLog':
@@ -224,4 +226,5 @@ export const cronjobTypes = [
     { value: 'ntp', label: i18n.global.t('cronjob.ntp') },
     { value: 'syncIpGroup', label: i18n.global.t('cronjob.syncIpGroup') },
     { value: 'cleanLog', label: i18n.global.t('cronjob.cleanLog') },
+    { value: 'compose', label: i18n.global.t('cronjob.compose') },
 ];

--- a/frontend/src/views/cronjob/cronjob/import/index.vue
+++ b/frontend/src/views/cronjob/cronjob/import/index.vue
@@ -173,6 +173,7 @@ const checkDataFormat = (item: any) => {
         'clean',
         'snapshot',
         'ntp',
+        'compose',
     ];
     if (!item.type || cronjobTypes.indexOf(item.type) === -1) {
         return false;

--- a/frontend/src/views/cronjob/cronjob/operate/index.vue
+++ b/frontend/src/views/cronjob/cronjob/operate/index.vue
@@ -300,6 +300,25 @@
                                         </el-select>
                                     </el-form-item>
                                 </LayoutCol>
+                                <LayoutCol v-if="form.type === 'compose'">
+                                    <el-form-item :label="$t('cronjob.compose')" prop="appIdList">
+                                        <el-select
+                                            clearable
+                                            v-model="form.appIdList"
+                                            multiple
+                                            @change="
+                                                form.appIdList = form.appIdList.includes('all')
+                                                    ? ['all']
+                                                    : form.appIdList
+                                            "
+                                        >
+                                            <el-option :label="$t('commons.table.all')" value="all" />
+                                            <div v-for="item in composeOptions" :key="item.name">
+                                                <el-option :value="item.name" :label="item.name" />
+                                            </div>
+                                        </el-select>
+                                    </el-form-item>
+                                </LayoutCol>
                                 <LayoutCol v-if="form.type === 'database'">
                                     <el-form-item :label="$t('cronjob.database')">
                                         <el-select v-model="form.dbType" @change="loadDatabases">
@@ -837,7 +856,7 @@ import { listDbItems } from '@/api/modules/database';
 import { getWebsiteOptions } from '@/api/modules/website';
 import { MsgError, MsgSuccess } from '@/utils/message';
 import { useRouter } from 'vue-router';
-import { listContainer } from '@/api/modules/container';
+import { listContainer, searchCompose } from '@/api/modules/container';
 import { Database } from '@/api/interface/database';
 import { listAppInstalled } from '@/api/modules/app';
 import {
@@ -1044,6 +1063,7 @@ const search = async () => {
     }
     loadBackups();
     loadAppInstalls();
+    loadComposeOptions();
     loadUserOptions(true);
     loadWebsites();
     loadContainers();
@@ -1064,6 +1084,7 @@ const websiteOptions = ref([]);
 const backupOptions = ref([]);
 const accountOptions = ref([]);
 const appOptions = ref([]);
+const composeOptions = ref<{ name: string }[]>([]);
 const userOptions = ref([]);
 const scriptOptions = ref([]);
 const groupOptions = ref([]);
@@ -1470,6 +1491,15 @@ const loadAppInstalls = async () => {
     appOptions.value = res.data || [];
 };
 
+const loadComposeOptions = async () => {
+    try {
+        const res = await searchCompose({ page: 1, pageSize: 1000, info: '' });
+        composeOptions.value = (res.data.items || []).map((item: any) => ({ name: item.name }));
+    } catch (e) {
+        composeOptions.value = [];
+    }
+};
+
 const loadWebsites = async () => {
     const res = await getWebsiteOptions({});
     websiteOptions.value = res.data || [];
@@ -1487,7 +1517,8 @@ function isBackup() {
         form.type === 'database' ||
         form.type === 'directory' ||
         form.type === 'snapshot' ||
-        form.type === 'log'
+        form.type === 'log' ||
+        form.type === 'compose'
     );
 }
 


### PR DESCRIPTION
## Summary

Adds `compose` as a new cronjob type for automatic Docker Compose backup. This was requested in #12250 (point 2) - the compose backup feature exists since v2.1.5 but has no scheduled task support.

This is a **small, focused PR** (~100 lines of logic) that wires the existing `ComposeBackup` function into the cronjob dispatcher. No new dependencies or models needed.

### Backend changes
- `cronjob_backup.go`: Add `handleCompose()` using existing `handleComposeBackup()` + `uploadWithMap()`
- `cronjob_helper.go`: Add `"compose"` case to `loadTask()`, update `hasBackup()`

### Frontend changes
- `helper.ts`: Add compose to type list and default spec
- `operate/index.vue`: Add compose project selector, update `isBackup()`
- `import/index.vue`: Add compose to import validation
- `en.ts` / `zh.ts`: Add `cronjob.compose` translation

### How it works
1. User creates cronjob with type "compose"
2. Selects specific compose projects or "all"
3. On schedule, calls existing `handleComposeBackup()` for each project
4. Uploads to backup account, manages retention - same as app/website backup

```release-note
feat: Add compose backup scheduled task type for automatic Docker Compose backups (#12250)
```