### PR TITLE
fix: trim whitespace from command in ExecComposer method

### DIFF
--- a/agent/app/service/website.go
+++ b/agent/app/service/website.go
@@ -2322,6 +2322,7 @@ func (w WebsiteService) ExecComposer(req request.ExecComposerReq) error {
 	} else {
 		command = req.ExtCommand
 	}
+	command = strings.TrimSpace(command)
 	resourceName := fmt.Sprintf("composer %s", command)
 	composerTask, err := task.NewTaskWithOps(resourceName, task.TaskExec, req.Command, req.TaskID, website.ID)
 	if err != nil {


### PR DESCRIPTION
#### What this PR does / why we need it?
fix https://github.com/1Panel-dev/1Panel/issues/12285

问题在网站-PHP-Composer
<img width="1848" height="979" alt="image" src="https://github.com/user-attachments/assets/8078d5ef-f527-4ad5-a88a-123c9866bcc5" />

#### Summary of your change
对最后composer拼接命令进行trimspace清理 避免多余空格

后期会给这个小模块前端和后端做对齐设计，比如自定义命令的判断和镜像源选择，目前发现迷惑性的东西挺多
#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.