### PR TITLE
fix: correct listening status display on the firewall page

### DIFF
--- a/agent/app/service/process.go
+++ b/agent/app/service/process.go
@@ -52,7 +52,12 @@ func (ps *ProcessService) GetListeningProcess(c context.Context) ([]ListeningPro
 	if err != nil {
 		return nil, err
 	}
-	procCache := make(map[int32]ListeningProcess, 64)
+	// One cache entry per (PID, socket type) so TCP and UDP sockets are not merged under one Protocol.
+	type procKey struct {
+		pid      int32
+		protocol uint32
+	}
+	procCache := make(map[procKey]ListeningProcess, 64)
 
 	for _, conn := range conn {
 		if conn.Pid == 0 {
@@ -60,7 +65,8 @@ func (ps *ProcessService) GetListeningProcess(c context.Context) ([]ListeningPro
 		}
 
 		if (conn.Status == "LISTEN" && conn.Type == syscall.SOCK_STREAM) || (conn.Type == syscall.SOCK_DGRAM && conn.Raddr.Port == 0) {
-			if _, exists := procCache[conn.Pid]; !exists {
+			key := procKey{pid: conn.Pid, protocol: conn.Type}
+			if _, exists := procCache[key]; !exists {
 				proc, err := process.NewProcess(conn.Pid)
 				if err != nil {
 					continue
@@ -72,11 +78,11 @@ func (ps *ProcessService) GetListeningProcess(c context.Context) ([]ListeningPro
 				procData.Port = make(map[uint32]struct{})
 				procData.Port[conn.Laddr.Port] = struct{}{}
 				procData.Protocol = conn.Type
-				procCache[conn.Pid] = procData
+				procCache[key] = procData
 			} else {
-				p := procCache[conn.Pid]
+				p := procCache[key]
 				p.Port[conn.Laddr.Port] = struct{}{}
-				procCache[conn.Pid] = p
+				procCache[key] = p
 			}
 		}
 	}


### PR DESCRIPTION
#### What this PR does / why we need it?
The bug only appeared when the same process had both TCP and UDP sockets: every listening port on that process was attributed to whichever protocol was encountered first. For example, if a process listened on TCP 8000 and UDP 8001, the UI could wrongly show TCP 8001 as in use while UDP 8001 looked unused.
<img width="3330" height="370" alt="image" src="https://github.com/user-attachments/assets/a10f6be0-ba64-45a0-a2f8-df3e62afbbf3" />

#### Summary of your change
Use (PID, conn.Type) as the cache key so each protocol has its own ListeningProcess entry.

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.