### PR TITLE
fix: clean up docker process in DownloadContainerLogs on timeout

### DIFF
--- a/agent/app/service/container.go
+++ b/agent/app/service/container.go
@@ -1076,14 +1076,18 @@ func (u *ContainerService) DownloadContainerLogs(containerType, container, since
 	}
 	stdout, err := dockerCmd.StdoutPipe()
 	if err != nil {
-		_ = dockerCmd.Process.Signal(syscall.SIGTERM)
 		return err
 	}
 	dockerCmd.Stderr = dockerCmd.Stdout
 	if err := dockerCmd.Start(); err != nil {
-		_ = dockerCmd.Process.Signal(syscall.SIGTERM)
 		return err
 	}
+	defer func() {
+		if dockerCmd.Process != nil {
+			_ = dockerCmd.Process.Kill()
+			_ = dockerCmd.Wait()
+		}
+	}()
 
 	tempFile, err := os.CreateTemp("", "cmd_output_*.txt")
 	if err != nil {


### PR DESCRIPTION
`DownloadContainerLogs` starts a `docker logs` child process but never
kills it when the 3-second read timeout fires. The function returns, the
HTTP response is sent, and the child process is reparented to PID 1.

On servers with many containers or large log files the timeout is easy to
hit, so these orphans accumulate over time.

This patch:
- adds a `defer` that kills and reaps the child process on every exit path
- removes two `Process.Signal()` calls that ran before `Start()`, which
  would panic on the nil `Process` pointer

```release-note
fix: clean up docker process in DownloadContainerLogs on timeout