### PR TITLE
fix(agent/file): NewIFileService should return IFileService, not FileService

### DIFF
--- a/agent/app/service/file.go
+++ b/agent/app/service/file.go
@@ -91,7 +91,7 @@ const (
 	fileRemarkEncodedMaxLen = 256
 )
 
-func NewIFileService() FileService {
+func NewIFileService() IFileService {
 	return &FileService{}
 }
 


### PR DESCRIPTION
## Summary

`agent/app/service/file.go:94` declares the constructor with a bare struct return type:

```go
func NewIFileService() FileService {
    return &FileService{}
}
```

But the body returns a pointer (`&FileService{}`), and the function name (`NewIFileService`) suggests the caller should receive the interface (`IFileService`).

## Repro

\`go build ./...\` on the \`agent\` module currently fails:

```
$ go build ./...
# github.com/1Panel-dev/1Panel/agent/app/service
app/service/file.go:95:9: cannot use &FileService{} (value of type *FileService) as FileService value in return statement
app/service/website_proxy.go:276:36: cannot call pointer method GetFileList on FileService
```

The second error is a downstream consequence: `website_proxy.go:276` calls `NewIFileService().GetFileList(...)`, which fails because `GetFileList` has a pointer receiver but `NewIFileService` is declared to return a value.

## Fix

One-line change: declare the return type as the interface.

```diff
-func NewIFileService() FileService {
+func NewIFileService() IFileService {
        return &FileService{}
 }
```

`*FileService` implements every method on `IFileService` (verified with `go vet ./...`).

## Verification

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean

## Notes

This regression appears to have been introduced in commit \`e57dc12\` (#12529 area). No other call sites of \`NewIFileService\` reference the concrete type; switching to the interface is fully source-compatible with existing consumers.