### PR TITLE
fix(cmd): use exec.LookPath in Which() so detection works without external 'which'

### DIFF
--- a/agent/utils/cmd/cmd.go
+++ b/agent/utils/cmd/cmd.go
@@ -29,6 +29,16 @@ func SudoHandleCmd() string {
 }
 
 func Which(name string) bool {
+	// Prefer Go's built-in PATH lookup so we don't depend on an external
+	// `which` binary, which is not installed by default on minimal
+	// distributions (e.g. Arch Linux, some Alpine images, slim containers).
+	// See 1Panel-dev/1Panel#12605.
+	if _, err := exec.LookPath(name); err == nil {
+		return true
+	}
+	// Fall back to shelling out for environments where PATH inside the
+	// agent process differs from the user's interactive shell PATH (the
+	// previous behaviour, preserved for compatibility).
 	stdout, err := RunDefaultWithStdoutBashCf("which %s", name)
 	if err != nil || (len(strings.ReplaceAll(stdout, "\n", "")) == 0) {
 		return false

--- a/agent/utils/cmd/cmd_test.go
+++ b/agent/utils/cmd/cmd_test.go
@@ -1,0 +1,23 @@
+package cmd
+
+import "testing"
+
+// TestWhich_ExistingBinary verifies that Which() returns true for a
+// binary that is guaranteed to exist on every Unix-like build host
+// (`sh`). Regression test for #12605: the previous implementation
+// shelled out to `which`, which is not always available on minimal
+// distributions like Arch Linux. The new implementation tries
+// exec.LookPath first, so this assertion holds regardless of whether
+// `which` itself is on PATH.
+func TestWhich_ExistingBinary(t *testing.T) {
+	if !Which("sh") {
+		t.Errorf("Which(\"sh\") = false, want true")
+	}
+}
+
+func TestWhich_MissingBinary(t *testing.T) {
+	// A binary name that is extremely unlikely to exist on any host.
+	if Which("definitely-not-a-real-binary-xyzzy-1panel") {
+		t.Errorf("Which(\"definitely-not-a-real-binary-xyzzy-1panel\") = true, want false")
+	}
+}

--- a/core/utils/cmd/cmd.go
+++ b/core/utils/cmd/cmd.go
@@ -17,6 +17,16 @@ func SudoHandleCmd() string {
 }
 
 func Which(name string) bool {
+	// Prefer Go's built-in PATH lookup so we don't depend on an external
+	// `which` binary, which is not installed by default on minimal
+	// distributions (e.g. Arch Linux, some Alpine images, slim containers).
+	// See 1Panel-dev/1Panel#12605.
+	if _, err := exec.LookPath(name); err == nil {
+		return true
+	}
+	// Fall back to shelling out for environments where PATH inside the
+	// agent process differs from the user's interactive shell PATH (the
+	// previous behaviour, preserved for compatibility).
 	stdout, err := RunDefaultWithStdoutBashCf("which %s", name)
 	if err != nil || (len(strings.ReplaceAll(stdout, "\n", "")) == 0) {
 		return false

--- a/core/utils/cmd/cmd_test.go
+++ b/core/utils/cmd/cmd_test.go
@@ -1,0 +1,23 @@
+package cmd
+
+import "testing"
+
+// TestWhich_ExistingBinary verifies that Which() returns true for a
+// binary that is guaranteed to exist on every Unix-like build host
+// (`sh`). Regression test for #12605: the previous implementation
+// shelled out to `which`, which is not always available on minimal
+// distributions like Arch Linux. The new implementation tries
+// exec.LookPath first, so this assertion holds regardless of whether
+// `which` itself is on PATH.
+func TestWhich_ExistingBinary(t *testing.T) {
+	if !Which("sh") {
+		t.Errorf("Which(\"sh\") = false, want true")
+	}
+}
+
+func TestWhich_MissingBinary(t *testing.T) {
+	// A binary name that is extremely unlikely to exist on any host.
+	if Which("definitely-not-a-real-binary-xyzzy-1panel") {
+		t.Errorf("Which(\"definitely-not-a-real-binary-xyzzy-1panel\") = true, want false")
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it?

Fixes #12605.

`cmd.Which()` previously shelled out to `which <name>` to determine whether a binary was on PATH. On distributions that do not ship a `which` package by default — **Arch Linux** is the canonical example, but the same applies to several minimal container images — `which` itself is missing from PATH, so every call to `Which()` returned `false`. As a result, 1Panel reported core dependencies (notably Docker) as not installed even when they were running normally:

```json
GET /api/v2/containers/docker/status
{"code":200,"message":"","data":{"isActive":false,"isExist":false}}
```

…on a host where `docker.service` was active, `docker version` worked, and `/var/run/docker.sock` was reachable. The reporter confirmed that simply dropping a stub `/usr/local/bin/which` script restored detection.

#### Summary of your change

Switch the primary path to Go's [`exec.LookPath`](https://pkg.go.dev/os/exec#LookPath), which uses the process PATH directly and has no external binary dependency. The original shell-out is **preserved as a fallback** so any environment where the agent's PATH differs from the user's interactive shell PATH (the reason the shell-out existed in the first place) keeps working unchanged.

Both copies of the helper are updated:

- `agent/utils/cmd/cmd.go`
- `core/utils/cmd/cmd.go`

```go
func Which(name string) bool {
    if _, err := exec.LookPath(name); err == nil {
        return true
    }
    // Fallback: original shell-out, preserved for compatibility.
    stdout, err := RunDefaultWithStdoutBashCf("which %s", name)
    if err != nil || (len(strings.ReplaceAll(stdout, "\\n", "")) == 0) {
        return false
    }
    return true
}
```

A small unit test is added to each package guarding the regression:

- `Which("sh")` is `true` (sh is on every Unix-like host the CI runs on, regardless of whether `which` itself is installed).
- `Which("definitely-not-a-real-binary-xyzzy-1panel")` is `false`.

#### Verification

```
$ cd agent && go test ./utils/cmd/ -v
=== RUN   TestWhich_ExistingBinary
--- PASS: TestWhich_ExistingBinary
=== RUN   TestWhich_MissingBinary
--- PASS: TestWhich_MissingBinary
PASS

$ cd core && go test ./utils/cmd/ -v
=== RUN   TestWhich_ExistingBinary
--- PASS: TestWhich_ExistingBinary
=== RUN   TestWhich_MissingBinary
--- PASS: TestWhich_MissingBinary
PASS
```

`go vet` and `gofmt` are both clean on the touched files.

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed. (No user-facing behaviour or docs change — `Which()` is internal.)