### PR TITLE
fix(ssl): support IPv6 hosts in panel SSL self-signed certificate flow

### DIFF
--- a/agent/app/service/website_ca.go
+++ b/agent/app/service/website_ca.go
@@ -188,7 +188,7 @@ func (w WebsiteCAService) ObtainSSL(req request.WebsiteCAObtain) (*model.Website
 			existDomains = append(existDomains, strings.Split(websiteSSL.Domains, ",")...)
 		}
 		for _, domain := range existDomains {
-			if ipAddress := net.ParseIP(domain); ipAddress == nil {
+			if ipAddress := common.ParseIPLoose(domain); ipAddress == nil {
 				domains = append(domains, domain)
 			} else {
 				ips = append(ips, ipAddress)
@@ -220,7 +220,7 @@ func (w WebsiteCAService) ObtainSSL(req request.WebsiteCAObtain) (*model.Website
 		if req.Domains != "" {
 			domainArray := strings.Split(req.Domains, "\n")
 			for _, domain := range domainArray {
-				if ipAddress := net.ParseIP(domain); ipAddress == nil {
+				if ipAddress := common.ParseIPLoose(domain); ipAddress == nil {
 					if domain != "localhost" && !common.IsValidDomain(domain) {
 						err = buserr.WithName("ErrDomainFormat", domain)
 						return nil, err

--- a/agent/utils/common/common.go
+++ b/agent/utils/common/common.go
@@ -346,6 +346,26 @@ func IsValidIP(ip string) bool {
 	return net.ParseIP(ip) != nil
 }
 
+// ParseIPLoose parses an IP address, accepting bracketed IPv6 forms
+// such as "[::1]" or "[fe80::1%eth0]" in addition to the bare forms
+// that net.ParseIP supports natively. It also trims surrounding
+// whitespace. Returns nil for non-IP input, matching net.ParseIP.
+//
+// This is required because some flows pass the host portion of a URL
+// (e.g. "[::1]") rather than a bare IP address. Rejecting that form
+// caused 1Panel-dev/1Panel#12646 — the panel SSL self-sign workflow
+// reported “domain format invalid” for IPv6 hosts.
+func ParseIPLoose(s string) net.IP {
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" {
+		return nil
+	}
+	if len(trimmed) >= 2 && trimmed[0] == '[' && trimmed[len(trimmed)-1] == ']' {
+		trimmed = trimmed[1 : len(trimmed)-1]
+	}
+	return net.ParseIP(trimmed)
+}
+
 const (
 	b  = uint64(1)
 	kb = 1024 * b

--- a/agent/utils/common/parse_ip_test.go
+++ b/agent/utils/common/parse_ip_test.go
@@ -1,0 +1,36 @@
+package common
+
+import "testing"
+
+// Regression test for 1Panel-dev/1Panel#12646: panel SSL self-signed flow
+// rejected IPv6 hosts because net.ParseIP does not accept the bracketed
+// form (e.g. "[::1]") and the upstream caller passes the host portion of
+// a URL rather than a bare IP.
+func TestParseIPLoose(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"bare ipv4", "127.0.0.1", true},
+		{"bare ipv6", "::1", true},
+		{"bracketed ipv6", "[::1]", true},
+		{"bracketed full ipv6", "[2001:db8::1]", true},
+		{"trimmed bare ipv6", "  ::1  ", true},
+		{"trimmed bracketed ipv6", "  [::1]  ", true},
+		{"empty", "", false},
+		{"only brackets", "[]", false},
+		{"hostname", "example.com", false},
+		{"bracketed garbage", "[notanip]", false},
+		{"unbalanced bracket left", "[::1", false},
+		{"unbalanced bracket right", "::1]", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ParseIPLoose(tc.in) != nil
+			if got != tc.want {
+				t.Errorf("ParseIPLoose(%q) ok = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/frontend/src/views/setting/safe/ssl/index.vue
+++ b/frontend/src/views/setting/safe/ssl/index.vue
@@ -243,8 +243,11 @@ const onSaveSSL = async (formEl: FormInstance | undefined) => {
                 cert: form.cert,
                 key: form.key,
             };
-            let href = window.location.href;
-            param.domain = href.split('//')[1].split(':')[0];
+            // window.location.hostname yields the bare host name and strips
+            // surrounding brackets from IPv6 addresses (e.g. '[::1]' -> '::1'),
+            // unlike `href.split('//')[1].split(':')[0]` which incorrectly
+            // returns '[' for IPv6 URLs. See 1Panel-dev/1Panel#12646.
+            param.domain = window.location.hostname;
             await updateSSL(param).then(() => {
                 MsgSuccess(i18n.global.t('commons.msg.operationSuccess'));
                 let href = window.location.href;


### PR DESCRIPTION
#### What this PR does / why we need it?

Fixes #12646.

Enabling **Panel SSL** with the **self-sign** provider rejected IPv6 hosts with `domain format invalid` (the screenshot in the issue shows the exact error). Two coupled bugs caused this.

##### Bug 1 — frontend host extraction is broken for IPv6 URLs

`frontend/src/views/setting/safe/ssl/index.vue` extracted the host from the current URL with:

```ts
let href = window.location.href;
param.domain = href.split('//')[1].split(':')[0];
```

For an IPv6 URL like `https://[::1]:1234`:

- `href.split('//')[1]` = `[::1]:1234`
- `.split(':')[0]` = `[`

…because the second `split` splits on the first `:` inside the bracketed address, leaving just the opening bracket. `[` then flows to the backend as the SSL domain, which fails the format check.

##### Bug 2 — backend rejects bracketed IPv6

`agent/app/service/website_ca.go`'s `ObtainSSL` used `net.ParseIP(domain)` directly:

```go
if ipAddress := net.ParseIP(domain); ipAddress == nil {
    if domain != "localhost" && !common.IsValidDomain(domain) {
        err = buserr.WithName("ErrDomainFormat", domain)
        return nil, err
    }
    ...
}
```

Even if the frontend correctly sent `[::1]`, `net.ParseIP` rejects the bracketed form, so it falls through to `IsValidDomain` and fails the regex. Both call sites in `ObtainSSL` (the renew path and the create path) had this bug.

#### Summary of your change

1. **Frontend** (`frontend/src/views/setting/safe/ssl/index.vue`): replace the manual `href` parse with `window.location.hostname`, which natively returns the bracket-stripped host for IPv6 URLs (e.g. `[::1]` → `::1`).

2. **Backend** (`agent/utils/common/common.go`): add a small exported helper `ParseIPLoose` that trims whitespace, strips matching outer `[` / `]`, and delegates to `net.ParseIP`. Use it at both call sites in `ObtainSSL` instead of `net.ParseIP`.

3. **Tests** (`agent/utils/common/parse_ip_test.go`): 12 cases covering bare IPv4/IPv6, bracketed IPv6, whitespace, empty input, only-brackets, hostnames, garbage, and unbalanced brackets.

Behaviour for all *non-IPv6-bracketed* inputs is unchanged.

#### Verification

```
$ cd agent && go test ./utils/common/ -v -run TestParseIPLoose
=== RUN   TestParseIPLoose
=== RUN   TestParseIPLoose/bare_ipv4
=== RUN   TestParseIPLoose/bare_ipv6
=== RUN   TestParseIPLoose/bracketed_ipv6
=== RUN   TestParseIPLoose/bracketed_full_ipv6
=== RUN   TestParseIPLoose/trimmed_bare_ipv6
=== RUN   TestParseIPLoose/trimmed_bracketed_ipv6
=== RUN   TestParseIPLoose/empty
=== RUN   TestParseIPLoose/only_brackets
=== RUN   TestParseIPLoose/hostname
=== RUN   TestParseIPLoose/bracketed_garbage
=== RUN   TestParseIPLoose/unbalanced_bracket_left
=== RUN   TestParseIPLoose/unbalanced_bracket_right
--- PASS: TestParseIPLoose (0.00s)  (12/12)
PASS
ok  github.com/1Panel-dev/1Panel/agent/utils/common
```

Format: `gofmt` clean on all touched files. `prettier --check` and `eslint` clean on the touched Vue file. `go vet` clean on `./utils/common/`.

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed. (No user-facing copy or behavioural change beyond accepting an input that previously errored. The user docs do not document the rejection.)