### PR TITLE
fix: parse supervisor uptime with optional days segment

### DIFF
--- a/agent/app/service/host_tool.go
+++ b/agent/app/service/host_tool.go
@@ -613,8 +613,7 @@ func getProcessStatus(config *response.SupervisorProcessConfig, containerName st
 				Status: fields[1],
 			}
 			if fields[1] == "RUNNING" {
-				status.PID = strings.TrimSuffix(fields[3], ",")
-				status.Uptime = fields[5]
+				status.PID, status.Uptime = parseSupervisorRunningDetails(fields)
 			} else {
 				status.Msg = strings.Join(fields[2:], " ")
 			}
@@ -622,4 +621,20 @@ func getProcessStatus(config *response.SupervisorProcessConfig, containerName st
 		}
 	}
 	return nil
+}
+
+func parseSupervisorRunningDetails(fields []string) (string, string) {
+	var pid, uptime string
+	if len(fields) > 3 && fields[2] == "pid" {
+		pid = strings.TrimSuffix(fields[3], ",")
+	}
+	for i := 4; i < len(fields); i++ {
+		if strings.TrimSuffix(fields[i], ",") == "uptime" {
+			if i+1 < len(fields) {
+				uptime = strings.Join(fields[i+1:], " ")
+			}
+			break
+		}
+	}
+	return pid, uptime
 }

--- a/agent/app/service/host_tool_test.go
+++ b/agent/app/service/host_tool_test.go
@@ -1,0 +1,52 @@
+package service
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseSupervisorRunningDetails(t *testing.T) {
+	tests := []struct {
+		name       string
+		line       string
+		wantPID    string
+		wantUptime string
+	}{
+		{
+			name:       "short uptime",
+			line:       "test:test_00 RUNNING pid 123, uptime 0:12:34",
+			wantPID:    "123",
+			wantUptime: "0:12:34",
+		},
+		{
+			name:       "single day uptime",
+			line:       "test:test_00 RUNNING pid 123, uptime 1 day, 0:12:34",
+			wantPID:    "123",
+			wantUptime: "1 day, 0:12:34",
+		},
+		{
+			name:       "multiple days uptime",
+			line:       "test:test_00 RUNNING pid 123, uptime 103 days, 0:12:34",
+			wantPID:    "123",
+			wantUptime: "103 days, 0:12:34",
+		},
+		{
+			name:       "process name is uptime",
+			line:       "uptime RUNNING pid 123, uptime 0:12:34",
+			wantPID:    "123",
+			wantUptime: "0:12:34",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pid, uptime := parseSupervisorRunningDetails(strings.Fields(tt.line))
+			if pid != tt.wantPID {
+				t.Fatalf("pid = %q, want %q", pid, tt.wantPID)
+			}
+			if uptime != tt.wantUptime {
+				t.Fatalf("uptime = %q, want %q", uptime, tt.wantUptime)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it?
 supervisorctl status reports running process uptime as part of the process description, for example:

```text
  pid 123, uptime 0:12:34
  pid 123, uptime 103 days, 0:12:34
```

  The previous parser used a fixed field index (fields[5]), which only worked for uptime values without the optional days segment. When the uptime contains days, only the day count was kept and the remaining time part was lost.
#### Summary of your change
- Parse RUNNING status details by locating the pid and uptime fields instead of relying on fixed indexes.
- Preserve the full uptime value by joining all fields after uptime.
- Add tests for standard Supervisor uptime formats with and without the optional days segment.
#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.

```release-note
Fix supervisor uptime parsing when `supervisorctl status` reports an uptime with days.
  ```