### PR TITLE
chore(deps): bump go-acme/lego to v5.2.2

### DIFF
--- a/agent/go.mod
+++ b/agent/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/gin-gonic/gin v1.12.0
 	github.com/glebarez/sqlite v1.11.0
-	github.com/go-acme/lego/v5 v5.2.1
+	github.com/go-acme/lego/v5 v5.2.2
 	github.com/go-gormigrate/gormigrate/v2 v2.1.5
 	github.com/go-playground/validator/v10 v10.30.2
 	github.com/go-redis/redis v6.15.9+incompatible

--- a/agent/go.sum
+++ b/agent/go.sum
@@ -296,8 +296,8 @@ github.com/go-acme/alidns-20150109/v5 v5.4.1 h1:Bp+EDtIGxBVKnIq1hPECBFf6eueTiESY
 github.com/go-acme/alidns-20150109/v5 v5.4.1/go.mod h1:L+SrZRmoQFx2UzOqng3z3+LA/gNgFCaLXrwr/ndyW6g=
 github.com/go-acme/esa-20240910/v3 v3.2.2 h1:dZ+HKddDMUcPr46gkFYdn5FbtJwIic59+MEaCaH/cxM=
 github.com/go-acme/esa-20240910/v3 v3.2.2/go.mod h1:qn4WK9pNgXoS5ypmiZfCWSYdOtWcte9GDuhDjKP752A=
-github.com/go-acme/lego/v5 v5.2.1 h1:LvOL09QvWBylPQ+YWCf/8nnewdtBdpqF7x1GuVSa0FI=
-github.com/go-acme/lego/v5 v5.2.1/go.mod h1:H/hb7OJKmpVGa8zypgZh0ys5P4VUu++ZNgAEcOwq+OI=
+github.com/go-acme/lego/v5 v5.2.2 h1:KqFas/Ak2QDdU+Qm7MO9OEnS35zC000kPmM+5tLdZKk=
+github.com/go-acme/lego/v5 v5.2.2/go.mod h1:H/hb7OJKmpVGa8zypgZh0ys5P4VUu++ZNgAEcOwq+OI=
 github.com/go-acme/tencentclouddnspod v1.3.24 h1:uCSiOW1EJttcnOON+MVVyVDJguFL/Q4NIGkq1CrT9p8=
 github.com/go-acme/tencentclouddnspod v1.3.24/go.mod h1:RKcB2wSoZncjBA0OEFj59s1ko1XDy+ZsAtk+9uMxUF0=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=


### PR DESCRIPTION
lego v5.2.2 (released 2026-06-02) is a single-fix patch on top of v5.2.1: the Namecheap DNS provider now derives the record key sub-domain correctly. 1Panel exposes the Namecheap provider through agent/utils/ssl/dns_provider.go, so this patch is meaningful for users issuing certificates against Namecheap-hosted zones.

Changes are confined to agent/go.mod and agent/go.sum; the source files under agent/utils/ssl/ already use the import path github.com/go-acme/lego/v5/... and require no code changes. Diff is a 6-line dependency bump (1 line in go.mod plus 4 lines of refreshed go.sum hashes); lego itself did not move any of its own dependency pins between v5.2.1 and v5.2.2.

Built and verified on linux/amd64:

  GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' ./...

agent and core binaries link cleanly against the upgraded lego release; no source-level adaptations needed.

#### What this PR does / why we need it?

#### Summary of your change

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.