### PR TITLE
feat: add Ionos DNS Provider

### DIFF
--- a/agent/utils/ssl/dns_provider.go
+++ b/agent/utils/ssl/dns_provider.go
@@ -225,7 +225,7 @@ func getDNSProviderConfig(dnsType DnsType, params string, httpClient *http.Clien
 		p, err = huaweicloud.NewDNSProviderConfig(config)
 	case Ionos:
 		config := newDNSProviderConfig(ionos.NewDefaultConfig(), httpClient)
-		config.APIKey = param.APIPrefix + '.' + param.APISecret
+		config.APIKey = param.APIPrefix + "." + param.APISecret
 		config.PropagationTimeout = propagationTimeout
 		config.PollingInterval = pollingInterval
 		config.TTL = ttl

--- a/agent/utils/ssl/dns_provider.go
+++ b/agent/utils/ssl/dns_provider.go
@@ -20,6 +20,8 @@ import (
 	"github.com/go-acme/lego/v5/providers/dns/freemyip"
 	"github.com/go-acme/lego/v5/providers/dns/godaddy"
 	"github.com/go-acme/lego/v5/providers/dns/huaweicloud"
+	"github.com/go-acme/lego/v5/providers/dns/ionos"
+	"github.com/go-acme/lego/v5/providers/dns/ionoscloud"
 	"github.com/go-acme/lego/v5/providers/dns/namecheap"
 	"github.com/go-acme/lego/v5/providers/dns/namedotcom"
 	"github.com/go-acme/lego/v5/providers/dns/namesilo"
@@ -37,34 +39,35 @@ import (
 )
 
 type DnsType string
-
 const (
+	AcmeDNS      DnsType = "AcmeDNS"
 	AliYun       DnsType = "AliYun"
 	AliESA       DnsType = "AliESA"
-	AWSRoute53   DnsType = "AWSRoute53"
-	CloudFlare   DnsType = "CloudFlare"
+	BaiduCloud   DnsType = "BaiduCloud"
 	CloudDns     DnsType = "CloudDns"
-	NameSilo     DnsType = "NameSilo"
+	CloudFlare   DnsType = "CloudFlare"
+	ClouDNS      DnsType = "ClouDNS"
+	Dynadot      DnsType = "Dynadot"
+	Dynu         DnsType = "Dynu"
+	FreeMyIP     DnsType = "FreeMyIP"
+	Godaddy      DnsType = "Godaddy"
+	HuaweiCloud  DnsType = "HuaweiCloud"
+	Ionos        DnsType = "Ionos"
+	IonosCloud   DnsType = "IonosCloud"
 	NameCheap    DnsType = "NameCheap"
 	NameCom      DnsType = "NameCom"
-	Godaddy      DnsType = "Godaddy"
-	TencentCloud DnsType = "TencentCloud"
-	RainYun      DnsType = "RainYun"
-	Volcengine   DnsType = "Volcengine"
-	HuaweiCloud  DnsType = "HuaweiCloud"
-	FreeMyIP     DnsType = "FreeMyIP"
-	Vercel       DnsType = "Vercel"
-	Spaceship    DnsType = "Spaceship"
-	WestCN       DnsType = "WestCN"
-	ClouDNS      DnsType = "ClouDNS"
-	RegRu        DnsType = "RegRu"
-	Dynu         DnsType = "Dynu"
-	Dynadot      DnsType = "Dynadot"
-	BaiduCloud   DnsType = "BaiduCloud"
+	NameSilo     DnsType = "NameSilo"
 	Ovh          DnsType = "Ovh"
-	AcmeDNS      DnsType = "AcmeDNS"
 	PorkBun      DnsType = "PorkBun"
+	RainYun      DnsType = "RainYun"
+	RegRu        DnsType = "RegRu"
+	AWSRoute53   DnsType = "AWSRoute53"
+	Spaceship    DnsType = "Spaceship"
 	Technitium   DnsType = "Technitium"
+	TencentCloud DnsType = "TencentCloud"
+	Vercel       DnsType = "Vercel"
+	Volcengine   DnsType = "Volcengine"
+	WestCN       DnsType = "WestCN"
 )
 
 type DNSParam struct {
@@ -76,6 +79,7 @@ type DNSParam struct {
 	APIkey       string `json:"apiKey"`
 	APIUser      string `json:"apiUser"`
 	APISecret    string `json:"apiSecret"`
+	APIPrefix    string `json:"apiPrefix"`
 	SecretID     string `json:"secretID"`
 	ClientID     string `json:"clientID"`
 	Password     string `json:"password"`
@@ -219,6 +223,20 @@ func getDNSProviderConfig(dnsType DnsType, params string, httpClient *http.Clien
 		config.PollingInterval = pollingInterval
 		config.TTL = int32(ttl)
 		p, err = huaweicloud.NewDNSProviderConfig(config)
+	case Ionos:
+		config := newDNSProviderConfig(ionos.NewDefaultConfig(), httpClient)
+		config.APIKey = param.APIPrefix + '.' + param.APISecret
+		config.PropagationTimeout = propagationTimeout
+		config.PollingInterval = pollingInterval
+		config.TTL = ttl
+		p, err = ionos.NewDNSProviderConfig(config)
+	case IonosCloud:
+		config := newDNSProviderConfig(ionoscloud.NewDefaultConfig(), httpClient)
+		config.APIToken = param.Token
+		config.PropagationTimeout = propagationTimeout
+		config.PollingInterval = pollingInterval
+		config.TTL = ttl
+		p, err = ionoscloud.NewDNSProviderConfig(config)
 	case FreeMyIP:
 		config := newDNSProviderConfig(freemyip.NewDefaultConfig(), httpClient)
 		config.Token = param.Token

--- a/frontend/src/global/mimetype.ts
+++ b/frontend/src/global/mimetype.ts
@@ -285,6 +285,14 @@ export const DNSTypes = [
         label: 'Technitium',
         value: 'Technitium',
     },
+    {
+        label: 'Ionos',
+        value: 'Ionos',
+    },
+    {
+        label: 'Ionos Cloud',
+        value: 'IonosCloud',
+    },
 ];
 
 export const Fields = [

--- a/frontend/src/views/website/ssl/dns-account/create/index.vue
+++ b/frontend/src/views/website/ssl/dns-account/create/index.vue
@@ -110,9 +110,17 @@
                             <el-input v-model.trim="account.authorization['token']"></el-input>
                         </el-form-item>
                     </div>
-                    <div v-if="account.type === 'FreeMyIP' || account.type === 'Vercel'">
+                    <div v-if="account.type === 'FreeMyIP' || account.type === 'Vercel' || account.type === 'IonosCloud'">
                         <el-form-item label="Token" prop="authorization.token">
                             <el-input v-model.trim="account.authorization['token']"></el-input>
+                        </el-form-item>
+                    </div>
+                    <div v-if="account.type === 'Ionos'">
+                        <el-form-item label="API Prefix" prop="authorization.apiPrefix">
+                            <el-input v-model.trim="account.authorization['apiPrefix']"></el-input>
+                        </el-form-item>
+                        <el-form-item label="API Secret" prop="authorization.apiSecret">
+                            <el-input v-model.trim="account.authorization['apiSecret']"></el-input>
                         </el-form-item>
                     </div>
                     <div v-if="account.type === 'ClouDNS'">
@@ -232,6 +240,7 @@ const rules = ref<any>({
         apiUser: [Rules.requiredInput],
         secretID: [Rules.requiredInput],
         apiSecret: [Rules.requiredInput],
+        apiPrefix: [Rules.requiredInput],
         username: [Rules.requiredInput],
         password: [Rules.requiredInput],
     },


### PR DESCRIPTION
#### What this PR does / why we need it?
#### What this PR does:

- Adds Ionos and Ionos Cloud to the list of supported DNS providers for automated SSL certificate generation (DNS-01 challenge).
- Updates the frontend UI (index.vue) to include specific form fields for these providers:
    - Ionos: Requires API Prefix and API Secret.
    - Ionos Cloud: Requires API Token.
#### Why we need it:
Currently, users who manage their domains through Ionos or Ionos Cloud cannot automate their SSL certificate provisioning through the platform.
#### Summary of your change

**Backend: New DNS Provider Support**

* Added imports and configuration logic for `ionos` and `ionoscloud` providers in `agent/utils/ssl/dns_provider.go`, including new handling for their credentials and API parameters. [[1]](diffhunk://#diff-8920d34b15fbdb1fd1085f7e3a7ee6ee1656692ef2edc851b9ee01ee0f9d7dedR23-R24) [[2]](diffhunk://#diff-8920d34b15fbdb1fd1085f7e3a7ee6ee1656692ef2edc851b9ee01ee0f9d7dedR226-R239)
* Updated the `DnsType` enum to include `Ionos` and `IonosCloud`.
* Added a new `APIPrefix` field to the `DNSParam` struct to support Ionos API credential requirements.
* **Reordered the enum for clarity**.

**Frontend: UI and Validation Updates**

* Added `Ionos` and `Ionos Cloud` to the selectable DNS types in the frontend (`frontend/src/global/mimetype.ts`).
* Updated the DNS account creation form to support input fields for Ionos (`apiPrefix`, `apiSecret`) and Ionos Cloud (`token`), including validation rules for these new fields. [[1]](diffhunk://#diff-38fc245fc2f3e18cd09ea6525a10dfe685def5527adc5d1a69392813a7b82a0cL113-R125) [[2]](diffhunk://#diff-38fc245fc2f3e18cd09ea6525a10dfe685def5527adc5d1a69392813a7b82a0cR243)

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact ~~and opened a new docs issue or PR with docs changes if needed~~.
    -  In case of a merge, Ionos and Ionos Cloud should be added to the supported DNS providers list here: https://1panel-dev.github.io/docs/v2/user_manual/websites/certificate_dns/