### PR TITLE
feat: add MiniMax M3 model to provider catalog

### DIFF
--- a/agent/app/provider/catalog.go
+++ b/agent/app/provider/catalog.go
@@ -163,10 +163,9 @@ var catalog = map[string]Meta{
 			Input:         []string{"text"},
 		},
 		Models: []Model{
+			{ID: "minimax/MiniMax-M3", Name: "MiniMax M3", ContextWindow: 1000000, MaxTokens: 128000, Reasoning: true, Input: []string{"text", "image"}},
 			{ID: "minimax/MiniMax-M2.7", Name: "MiniMax M2.7"},
 			{ID: "minimax/MiniMax-M2.7-highspeed", Name: "MiniMax M2.7 highspeed"},
-			{ID: "minimax/MiniMax-M2.5", Name: "MiniMax M2.5", Reasoning: true},
-			{ID: "minimax/MiniMax-M2.5-highspeed", Name: "MiniMax M2.5 highspeed"},
 		},
 	},
 	"xiaomi": {

--- a/agent/app/provider/verify.go
+++ b/agent/app/provider/verify.go
@@ -131,7 +131,7 @@ func BuildVerifyRequest(provider, baseURL, apiKey string) VerifyRequest {
 			request.URL = base + "/v1/messages"
 		}
 		request.Body = mustJSON(map[string]interface{}{
-			"model":      "MiniMax-M2.5",
+			"model":      "MiniMax-M3",
 			"max_tokens": 1,
 			"messages": []map[string]interface{}{{
 				"role": "user",


### PR DESCRIPTION
#### What this PR does / why we need it?

The MiniMax provider is already supported in the agent AI provider catalog, but its model list is missing the current flagship model, **MiniMax-M3**. This PR adds M3 and sets it as the default, so users selecting the MiniMax provider get the latest model out of the box.

#### Summary of your change

- Add `minimax/MiniMax-M3` to the MiniMax provider model list in `agent/app/provider/catalog.go`, placed first so it becomes the default model. M3 specs: 1M context window, 128K max output, reasoning, image input.
- Keep `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as alternatives.
- Remove the older `MiniMax-M2.5` / `MiniMax-M2.5-highspeed` entries.
- Update the MiniMax account verification probe in `agent/app/provider/verify.go` to use `MiniMax-M3` (the previous probe referenced the now-removed M2.5).

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.