### PR TITLE
ci: pin third-party actions to full commit SHAs

### DIFF
--- a/.github/workflows/llm-code-review.yml
+++ b/.github/workflows/llm-code-review.yml
@@ -9,7 +9,7 @@ jobs:
   llm-code-review:
     runs-on: ubuntu-latest
     steps:
-      - uses: fit2cloud/LLM-CodeReview-Action@main
+      - uses: fit2cloud/LLM-CodeReview-Action@016b651a0e3c47994f2ae630415986c89694d01a # main
         env:
           GITHUB_TOKEN: ${{ secrets.FIT2CLOUDRD_LLM_CODE_REVIEW_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.ALIYUN_LLM_API_KEY }}

--- a/.github/workflows/sonarcloud-scan.yml
+++ b/.github/workflows/sonarcloud-scan.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarcloud-github-action@ba3875ecf642b2129de2b589510c81a8b53dbf4e # master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUBTOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sync2gitee.yml
+++ b/.github/workflows/sync2gitee.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Mirror the Github organization repos to Gitee.
-        uses: Yikun/hub-mirror-action@master
+        uses: Yikun/hub-mirror-action@ba51c01b28a6c9f95a25d4f1bcf6af2a147c0e18 # master
         with:
           src: 'github/1Panel-dev'
           dst: 'gitee/fit2cloud-feizhiyun'

--- a/.github/workflows/tyops-check.yml
+++ b/.github/workflows/tyops-check.yml
@@ -8,4 +8,4 @@ jobs:
     - name: Checkout Actions Repository
       uses: actions/checkout@v2
     - name: Check spelling
-      uses: crate-ci/typos@master
+      uses: crate-ci/typos@3bc303c295c081add5df4a4d52a1e117f2fb2dce # master


### PR DESCRIPTION
### What

Pin the third-party actions currently referenced by `@master`/`@main` to their current commit SHA
(tag kept in a trailing comment):

| Action | Where | Secrets in that job |
|---|---|---|
| `SonarSource/sonarcloud-github-action@master` | `sonarcloud-scan.yml` | `SONAR_TOKEN` |
| `Yikun/hub-mirror-action@master` | `sync2gitee.yml` | `GITEE_PRIVATE_KEY`, `GITEE_TOKEN` |
| `fit2cloud/LLM-CodeReview-Action@main` | `llm-code-review.yml` | review token + LLM API key |
| `crate-ci/typos@master` | `tyops-check.yml` | — |

### Why

`@master`/`@main` are moving references — whatever they point to at run time runs in the job. Several of
these jobs hand the action real secrets (notably `sync2gitee.yml`, which passes a Gitee SSH private key
and token). If any of these actions' default branch were moved (compromise or an accidental change),
the new code would run with those secrets — the class of issue behind the 2025 `tj-actions/changed-files`
incident.

### Scope / safety

- Behaviour unchanged — each SHA is the current tip of that action's default branch.
- Only third-party actions are touched; `actions/*` refs are left as-is. Renovate/Dependabot can still
  bump a SHA pin (the tag comment keeps it readable).

Per GitHub's guidance to [pin actions to a full-length commit SHA](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

<sub>AI-assisted; I verified the workflows, the secret exposure, and the pinned SHAs myself.</sub>
