### PR TITLE
Add MCP Toplist rank badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![MCP Toplist](https://mcptoplist.com/badge/mcp.so%2F1Panel%2F1Panel-dev.svg)](https://mcptoplist.com/server/mcp.so%2F1Panel%2F1Panel-dev)
+
 <p align="center"><a href="https://1panel.pro"><img src="https://resource.1panel.pro/img/1panel-logo.png" alt="1Panel" width="300" /></a></p>
 
 <h3 align="center">The open-source VPS control panel with native AI agent support</h3>


### PR DESCRIPTION
Hi! [MCP Toplist](https://mcptoplist.com) tracks 81,432 MCP servers across the major
registries, and **1Panel MCP Server** is currently ranked **#55**.

This PR adds a small live badge to your README showing that rank — it updates
automatically as the leaderboard changes:

[![MCP Toplist](https://mcptoplist.com/badge/mcp.so%2F1Panel%2F1Panel-dev.svg)](https://mcptoplist.com/server/mcp.so%2F1Panel%2F1Panel-dev)

Totally fine to close if you'd rather not — and if you'd like your server's
data corrected or removed from the leaderboard, just say so here or open an
issue at the site. Thanks for building 1Panel MCP Server!
