### PR TITLE
feat(ai-agents): accept video input for MiniMax M3 model

### DIFF
--- a/agent/app/service/agents_utils.go
+++ b/agent/app/service/agents_utils.go
@@ -1118,6 +1118,9 @@ func buildOpenclawAccountModelConfig(account *model.AgentAccount, model dto.Agen
 
 var openclawVisionModelPattern = regexp.MustCompile(`(?i)(\b(gpt-4o|gpt-4\.1|gpt-[5-9]|o[134])\b|\bclaude-(3|4|sonnet|opus|haiku)\b|\bgemini\b|\b(qwen[\w.-]*-?vl|qwen-vl|qwen3\.[5-9]-plus)\b|\b(kimi-k2\.(5|6)|kimi-k2\.7-code|minimax-m3)\b|\b(vision|llava|pixtral|internvl|mllama|minicpm-v|glm-4v|omni)\b|(^|[-_/])vl([-_/]|$))`)
 
+// openclawVideoInputModelPattern matches vision models that additionally accept video input.
+var openclawVideoInputModelPattern = regexp.MustCompile(`(?i)\bminimax-m3\b`)
+
 func buildOpenclawModelEntry(modelID string, model dto.AgentAccountModel) modelEntry {
 	name := strings.TrimSpace(model.Name)
 	if name == "" {
@@ -1126,6 +1129,9 @@ func buildOpenclawModelEntry(modelID string, model dto.AgentAccountModel) modelE
 	entry := modelEntry{ID: strings.TrimSpace(modelID), Name: name}
 	if openclawVisionModelPattern.MatchString(modelID) {
 		entry.Input = []string{"text", "image"}
+		if openclawVideoInputModelPattern.MatchString(modelID) {
+			entry.Input = []string{"text", "image", "video"}
+		}
 	}
 	return entry
 }

--- a/agent/app/service/agents_utils_input_test.go
+++ b/agent/app/service/agents_utils_input_test.go
@@ -1,0 +1,54 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/1Panel-dev/1Panel/agent/app/dto"
+)
+
+func TestBuildOpenclawModelEntryInputModalities(t *testing.T) {
+	cases := []struct {
+		name      string
+		modelID   string
+		model     dto.AgentAccountModel
+		wantInput []string
+	}{
+		{
+			name:      "minimax m3 accepts text image and video",
+			modelID:   "MiniMax-M3",
+			model:     dto.AgentAccountModel{ID: "MiniMax-M3", Name: "MiniMax M3"},
+			wantInput: []string{"text", "image", "video"},
+		},
+		{
+			name:      "minimax m3 lowercased accepts video",
+			modelID:   "minimax-m3",
+			model:     dto.AgentAccountModel{ID: "minimax-m3"},
+			wantInput: []string{"text", "image", "video"},
+		},
+		{
+			name:      "minimax m2.7 stays text only",
+			modelID:   "MiniMax-M2.7",
+			model:     dto.AgentAccountModel{ID: "MiniMax-M2.7", Name: "MiniMax M2.7"},
+			wantInput: nil,
+		},
+		{
+			name:      "claude sonnet accepts text and image",
+			modelID:   "claude-sonnet-4-5",
+			model:     dto.AgentAccountModel{ID: "claude-sonnet-4-5"},
+			wantInput: []string{"text", "image"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			entry := buildOpenclawModelEntry(tc.modelID, tc.model)
+			if len(entry.Input) != len(tc.wantInput) {
+				t.Fatalf("input length: got %v, want %v", entry.Input, tc.wantInput)
+			}
+			for i, want := range tc.wantInput {
+				if entry.Input[i] != want {
+					t.Fatalf("input[%d]: got %q, want %q", i, entry.Input[i], want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Reason: MiniMax M3 advertises video input, but the account-model sanitizer only accepted text and image.

## Changes

- `agent/app/service/agents_utils.go`: add `openclawVideoInputModelPattern` (matches `minimax-m3`) and extend the model entry input modalities to `["text", "image", "video"]` for matching vision models in `buildOpenclawModelEntry`. Other vision models keep `["text", "image"]`.
- `agent/app/service/agents_utils_input_test.go`: add unit tests covering MiniMax-M3 (video), MiniMax-M2.7 (text only), and a non-MiniMax vision model (text + image).

## Checks

- `git diff` secret scan (clean).
- Go toolchain was not available in the worker environment, so `go build`/`go test` were not executed here; the change is a small, self-contained addition to an existing regex-based branch and is covered by the new test.
