### PR TITLE
docs: name Halo in website deployment overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 1Panel is a modern, open-source Linux server management panel and a lightweight AI management platform. Through an intuitive web interface, it provides users with comprehensive, one-stop server management capabilities:
 - **AI Management**: Offers a unified management platform from bare metal to agents (Metal-to-Agent). It integrates an AI gateway, and Skills Hub, while supporting centralized management of agents and models.
 - **Efficient Visual Operations**: Easily manage Linux servers through a web-based GUI, streamlining tasks such as host monitoring, file management, database management, and container management.
-- **Rapid Website Deployment**: Deeply integrates with popular website builders like WordPress and . It enables one-click domain binding and SSL certificate configuration, significantly lowering the barrier to website creation.
+- **Rapid Website Deployment**: Deeply integrates with popular website builders like WordPress and Halo. It enables one-click domain binding and SSL certificate configuration, significantly lowering the barrier to website creation.
 - **Curated App Store**: Features a built-in store of high-quality open-source applications, providing one-click installation and upgrade services to effortlessly extend server capabilities.
 - **Enterprise-Grade Security**: Deploys applications based on container technology to effectively minimize vulnerability exposure. It also provides security features such as WAF and log auditing to ensure comprehensive server protection.
 - **One-Click Data Backup**: Supports one-click backup and restoration, and integrates with various cloud storage solutions to ensure data security and prevent loss.


### PR DESCRIPTION
#### What this PR does / why we need it?

The English README currently says "WordPress and ." in the Rapid Website Deployment overview. This leaves the second supported website builder unnamed and makes the sentence incomplete.

#### Summary of your change

- Add the missing product name, `Halo`, to the English README.
- Keep the statement aligned with the Simplified Chinese README, which already names WordPress and Halo.

#### Please indicate you've done the following:

- [x] Verified the README-local links with a local checker.
- [x] Verified the change with `git diff --check`.
- [x] Used a Conventional Commits-style commit message.
- [x] No additional documentation changes are required for this one-line correction.