### PR TITLE
fix: deduplicate port bindings in container port mapping

### DIFF
--- a/agent/app/service/container.go
+++ b/agent/app/service/container.go
@@ -16,6 +16,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -1758,7 +1759,10 @@ func checkPortStats(ports []dto.PortHelper, checkInUse bool) (nat.PortMap, error
 			}
 			for i := 0; i <= hostEnd-hostStart; i++ {
 				bindItem := nat.PortBinding{HostPort: strconv.Itoa(hostStart + i), HostIP: port.HostIP}
-				portMap[nat.Port(fmt.Sprintf("%d/%s", containerStart+i, port.Protocol))] = []nat.PortBinding{bindItem}
+				portKey := nat.Port(fmt.Sprintf("%d/%s", containerStart+i, port.Protocol))
+				if !slices.Contains(portMap[portKey], bindItem) {
+					portMap[portKey] = append(portMap[portKey], bindItem)
+				}
 			}
 			for i := hostStart; i <= hostEnd; i++ {
 				if checkInUse && common.ScanPortWithIP(port.HostIP, i) {
@@ -1776,7 +1780,10 @@ func checkPortStats(ports []dto.PortHelper, checkInUse bool) (nat.PortMap, error
 				return portMap, buserr.WithDetail("ErrPortInUsed", portItem, nil)
 			}
 			bindItem := nat.PortBinding{HostPort: strconv.Itoa(portItem), HostIP: port.HostIP}
-			portMap[nat.Port(fmt.Sprintf("%s/%s", port.ContainerPort, port.Protocol))] = []nat.PortBinding{bindItem}
+			portKey := nat.Port(fmt.Sprintf("%s/%s", port.ContainerPort, port.Protocol))
+			if !slices.Contains(portMap[portKey], bindItem) {
+				portMap[portKey] = append(portMap[portKey], bindItem)
+			}
 		}
 	}
 	return portMap, nil
@@ -1955,7 +1962,7 @@ func loadComposeCount(client *client.Client) int {
 }
 func loadContainerPortForInfo(itemPorts []container.Port) []dto.PortHelper {
 	var exposedPorts []dto.PortHelper
-	samePortMap := make(map[string]dto.PortHelper)
+	seenPorts := make(map[dto.PortHelper]struct{})
 	ports := transPortToStr(itemPorts)
 	for _, item := range ports {
 		itemStr := strings.Split(item, "->")
@@ -1976,16 +1983,11 @@ func loadContainerPortForInfo(itemPorts []container.Port) []dto.PortHelper {
 		}
 		itemPort.ContainerPort = itemContainer[0]
 		itemPort.Protocol = itemContainer[1]
-		keyItem := fmt.Sprintf("%s->%s/%s", itemPort.HostPort, itemPort.ContainerPort, itemPort.Protocol)
-		if val, ok := samePortMap[keyItem]; ok {
-			val.HostIP = ""
-			samePortMap[keyItem] = val
-		} else {
-			samePortMap[keyItem] = itemPort
+		if _, exists := seenPorts[itemPort]; exists {
+			continue
 		}
-	}
-	for _, val := range samePortMap {
-		exposedPorts = append(exposedPorts, val)
+		seenPorts[itemPort] = struct{}{}
+		exposedPorts = append(exposedPorts, itemPort)
 	}
 	return exposedPorts
 }


### PR DESCRIPTION
#### What this PR does / why we need it?
<img width="1832" height="1132" alt="image" src="https://github.com/user-attachments/assets/3e05cbfa-b5b5-4fd9-bfe7-818f6197f591" />

修复容器端口暴露问题：
我想对mysql容器的3306 进行暴露，
本地3306->容器3306 （给局域网访问3306）
本地33060->容器3306 （给外网访问33060）
结果代码bug使用容器3306端口作为key，导致规则添加时只有一个成功，另一个失败
本地构建并且操作测试了一下没问题

Fix container port exposure issue: 
I want to expose port 3306 of the MySQL container, mapping local 3306 to container 3306 (for LAN access to 3306) and local 33060 to container 3306 (for external WAN access via 33060). 
However, a code bug uses the container port 3306 as the key, resulting in a duplicate key conflict that causes the rule addition to fail.

#### Summary of your change

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.