### PR TITLE
fix(fail2ban): treat process as active when client ping succeeds

### DIFF
--- a/agent/utils/toolbox/fail2ban.go
+++ b/agent/utils/toolbox/fail2ban.go
@@ -42,8 +42,19 @@ func (f *Fail2ban) Status() (bool, bool, bool) {
 	isEnable, _ := controller.CheckEnable("fail2ban.service")
 	isActive, _ := controller.CheckActive("fail2ban.service")
 	isExist, _ := controller.CheckExist("fail2ban.service")
+	if !isActive && isFail2banAlive() {
+		isActive = true
+	}
 
 	return isEnable, isActive, isExist
+}
+
+func isFail2banAlive() bool {
+	stdout, err := cmd.NewCommandMgr(cmd.WithTimeout(5*time.Second)).RunWithStdout("fail2ban-client", "ping")
+	if err != nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(stdout), "pong")
 }
 
 func (f *Fail2ban) Version() string {


### PR DESCRIPTION
#### What this PR does / why we need it?

Fail2ban 工具箱页面目前只用 systemd `fail2ban.service` 判断 `isActive`。前端在 `!isActive` 时会禁用白名单/黑名单按钮。

当 fail2ban-server 实际仍在运行（例如由其他进程管理器拉起，或 systemd 已 inactive 但 daemon 还在）时，`fail2ban-client ping` 能返回 pong，但页面会显示已停止，黑白名单无法设置。

#### Summary of your change

- 在 `agent/utils/toolbox/fail2ban.go` 的 `Status()` 中，若 systemd 不是 active，再检查 `fail2ban-client ping`
- ping 返回 pong 时将 `isActive` 视为 true
- 不改变 start/stop/enable/disable 的 systemd 实现

Fixes #13678

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
