### PR TITLE
feat(ai): add DaoXE as a model provider

### DIFF
--- a/agent/app/provider/catalog.go
+++ b/agent/app/provider/catalog.go
@@ -156,6 +156,22 @@ var catalog = map[string]Meta{
 		},
 		Models: []Model{{ID: "openrouter/free", Name: "openrouter/free"}, {ID: "openrouter/auto", Name: "openrouter/auto"}},
 	},
+	// DaoXE (https://daoxe.com): OpenAI-compatible multi-model gateway; also serves Anthropic Messages.
+	"daoxe": {
+		Key: "daoxe", DisplayName: "DaoXE", Sort: 57, DefaultAPIType: "openai-completions", EnvKey: "DAOXE_API_KEY",
+		APIConfigs: []APIConfig{
+			{
+				APIType: "openai-completions", BaseURL: "https://api.daoxe.com/v1",
+				DiscoverModels: true,
+			},
+			{
+				APIType: "openai-responses", BaseURL: "https://api.daoxe.com/v1",
+				DiscoverModels: true,
+			},
+			{APIType: "openai-embeddings", BaseURL: "https://api.daoxe.com/v1"},
+			anthropicAPIConfig("https://api.daoxe.com", AuthModeXAPIKey, AuthModeBearer),
+		},
+	},
 	"anthropic": {
 		Key: "anthropic", DisplayName: "Anthropic", Sort: 60, DefaultAPIType: "anthropic-messages", EnvKey: "ANTHROPIC_API_KEY",
 		APIConfigs: []APIConfig{anthropicAPIConfig("https://api.anthropic.com", AuthModeXAPIKey)},
@@ -473,6 +489,7 @@ var legacyModelPrefixes = map[string][]string{
 	"kimi-coding":         {"kimi-coding"},
 	"openai":              {"openai"},
 	"anthropic":           {"anthropic"},
+	"daoxe":               {"daoxe"},
 	"gemini":              {"google", "gemini"},
 	"moonshot":            {"moonshot"},
 }

--- a/frontend/src/utils/agent-provider-logo.ts
+++ b/frontend/src/utils/agent-provider-logo.ts
@@ -9,6 +9,12 @@ export interface AgentProviderLogo {
 
 const asset = (name: string) => new URL(`../assets/images/ai-providers/${name}`, import.meta.url).href;
 
+// DaoXE brand mark (indigo-to-teal rounded square), inlined as a data URI so no binary
+// asset has to be added to the repository. Same 32x32 SVG that daoxe.com uses as favicon.
+const daoxeLogoDataUri =
+    'data:image/svg+xml;base64,' +
+    'PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzMiAzMiIgcm9sZT0iaW1nIiBhcmlhLWxhYmVsPSJEYW9YRSI+CiAgPGRlZnM+CiAgICA8bGluZWFyR3JhZGllbnQgaWQ9ImciIHgxPSIwIiB5MT0iMCIgeDI9IjEiIHkyPSIxIj4KICAgICAgPHN0b3Agb2Zmc2V0PSIwIiBzdG9wLWNvbG9yPSIjNjM2NmYxIi8+CiAgICAgIDxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iIzBlYTVhNCIvPgogICAgPC9saW5lYXJHcmFkaWVudD4KICA8L2RlZnM+CiAgPHJlY3QgeD0iMSIgeT0iMSIgd2lkdGg9IjMwIiBoZWlnaHQ9IjMwIiByeD0iOCIgZmlsbD0idXJsKCNnKSIvPgogIDxwYXRoIGQ9Ik0xMC41IDkuNSBMMTYgMTYgTDEwLjUgMjIuNSIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjZmZmZmZmIiBzdHJva2Utd2lkdGg9IjIuNiIKICAgICAgICBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz4KICA8cmVjdCB4PSIxNy41IiB5PSIyMC40IiB3aWR0aD0iNi40IiBoZWlnaHQ9IjIuNCIgcng9IjEuMiIgZmlsbD0iI2ZmZmZmZiIvPgo8L3N2Zz4K';
+
 const aliyunLogo: AgentProviderLogo = {
     src: asset('aliyun.webp'),
     mark: 'QW',
@@ -111,6 +117,14 @@ const providerLogos: Record<string, AgentProviderLogo> = {
         color: '#101828',
         borderColor: '#dcdfe6',
         source: 'https://openrouter.ai/',
+    },
+    daoxe: {
+        src: daoxeLogoDataUri,
+        mark: 'DX',
+        background: '#ffffff',
+        color: '#6366f1',
+        borderColor: '#dcdfe6',
+        source: 'https://daoxe.com/',
     },
     anthropic: {
         src: asset('anthropic.png'),


### PR DESCRIPTION
#### What this PR does / why we need it?

Adds [DaoXE](https://daoxe.com) as a selectable AI agent model provider. DaoXE is an
OpenAI-compatible multi-model LLM gateway (hundreds of models behind one API key) that
also serves Anthropic Messages on the same account, so it can back both OpenAI-type and
Claude-type agent flows in 1Panel.

Affiliation disclosure for transparency: I maintain this gateway, and this PR registers
it in the provider catalog the same way existing gateways (OpenRouter, DeepSeek, ...)
are registered.

#### Summary of your change

- `agent/app/provider/catalog.go`: new `daoxe` entry (Sort 57, next to OpenRouter) with
  `openai-completions` / `openai-responses` / `openai-embeddings` on
  `https://api.daoxe.com/v1` (model discovery enabled — standard `GET /v1/models`) and an
  `anthropic-messages` config on `https://api.daoxe.com` (x-api-key default, bearer
  optional). Added to `legacyModelPrefixes`. No hardcoded model list: models are
  discovered at runtime, so the entry stays correct as the catalog behind it changes.
- `frontend/src/utils/agent-provider-logo.ts`: provider logo, inlined as an SVG data URI
  so no binary asset is added to the repo (happy to switch to a committed
  `ai-providers/daoxe.svg` if maintainers prefer the file convention).
- No `verify.go` / `openclaw.go` / agents special-cases needed: DaoXE is a keyed provider
  using the standard bearer-verification path (unlike ollama/llmman local runners).

**Testing:** `go build` / `go vet` / `gofmt -l` on `agent/app/provider`,
`agent/app/service`, `agent/utils/terminal/ai` pass; `prettier --check` and `eslint` pass
on the touched frontend file; live `GET /v1/models` on the gateway verified to return the
standard `{"data": [...]}` shape used by `DiscoverModels`. Not yet run against a live
1Panel/OpenClaw deployment.

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
