### PR TITLE
style(terminal): 优化终端快捷入口多语言文案

### DIFF
--- a/frontend/src/lang/modules/en.ts
+++ b/frontend/src/lang/modules/en.ts
@@ -2068,8 +2068,9 @@ const message = {
         profileBlockDesc: 'Measures blocking on channels, select statements, and synchronization primitives.',
     },
     terminal: {
-        showTerminalButton: 'Show Terminal Button',
-        showTerminalButtonHelper: 'Show the terminal shortcut button in the bottom-right corner of the page.',
+        showTerminalButton: 'Terminal Shortcut',
+        showTerminalButtonHelper:
+            'When enabled, a terminal shortcut button appears in the bottom-right corner of the page.',
         local: 'Local',
         defaultConn: 'Default Connection',
         defaultConnHelper:

--- a/frontend/src/lang/modules/es-es.ts
+++ b/frontend/src/lang/modules/es-es.ts
@@ -2107,8 +2107,9 @@ const message = {
         profileBlockDesc: 'Mide los bloqueos en canales, select y primitivas de sincronización.',
     },
     terminal: {
-        showTerminalButton: 'Mostrar botón de terminal',
-        showTerminalButtonHelper: 'Mostrar el botón de acceso al terminal en la esquina inferior derecha de la página.',
+        showTerminalButton: 'Acceso rápido al terminal',
+        showTerminalButtonHelper:
+            'Al activar esta opción, se mostrará un botón de acceso rápido al terminal en la esquina inferior derecha de la página.',
         local: 'Local',
         defaultConn: 'Conexión predeterminada',
         defaultConnHelper:

--- a/frontend/src/lang/modules/fa.ts
+++ b/frontend/src/lang/modules/fa.ts
@@ -2049,8 +2049,9 @@ const message = {
         profileBlockDesc: 'زمان انسداد روی Channel، Select و ابزارهای همگام‌سازی را اندازه‌گیری می‌کند.',
     },
     terminal: {
-        showTerminalButton: 'نمایش دکمه ترمینال',
-        showTerminalButtonHelper: 'نمایش دکمه میانبر ترمینال در گوشه پایین سمت راست صفحه.',
+        showTerminalButton: 'میانبر ترمینال',
+        showTerminalButtonHelper:
+            'با فعال‌سازی این گزینه، دکمه میانبر ترمینال در گوشه پایین سمت راست صفحه نمایش داده می‌شود.',
         local: 'محلی',
         defaultConn: 'اتصال پیش‌فرض',
         defaultConnHelper:

--- a/frontend/src/lang/modules/ja.ts
+++ b/frontend/src/lang/modules/ja.ts
@@ -2057,8 +2057,8 @@ const message = {
         profileBlockDesc: 'Channel、Select、同期プリミティブでのブロック待機時間を測定します。',
     },
     terminal: {
-        showTerminalButton: 'ターミナルボタンを表示',
-        showTerminalButtonHelper: 'ページの右下にターミナルのショートカットボタンを表示します。',
+        showTerminalButton: 'ターミナルへのショートカット',
+        showTerminalButtonHelper: '有効にすると、ページの右下にターミナルへのショートカットボタンが表示されます。',
         local: 'ローカル',
         defaultConn: 'デフォルト接続',
         defaultConnHelper:

--- a/frontend/src/lang/modules/ko.ts
+++ b/frontend/src/lang/modules/ko.ts
@@ -2031,8 +2031,8 @@ const message = {
         profileBlockDesc: 'Channel, Select 및 동기화 프리미티브의 차단 대기 시간을 측정합니다.',
     },
     terminal: {
-        showTerminalButton: '터미널 버튼 표시',
-        showTerminalButtonHelper: '페이지 오른쪽 아래에 터미널 바로가기 버튼을 표시합니다.',
+        showTerminalButton: '터미널 바로가기',
+        showTerminalButtonHelper: '활성화하면 페이지 오른쪽 하단에 터미널 바로가기 버튼이 표시됩니다.',
         local: '로컬',
         defaultConn: '기본 연결',
         defaultConnHelper: '이 작업은 【{0}】의 터미널을 연 후 자동으로 노드 터미널에 연결됩니다. 계속하시겠습니까?',

--- a/frontend/src/lang/modules/lo.ts
+++ b/frontend/src/lang/modules/lo.ts
@@ -2015,8 +2015,8 @@ const message = {
         profileBlockDesc: 'ວັດແທກການບລັອກໃນ Channel, Select Statement ແລະ ກົນໄກ Synchronization.',
     },
     terminal: {
-        showTerminalButton: 'ສະແດງປຸ່ມ Terminal',
-        showTerminalButtonHelper: 'ສະແດງປຸ່ມທາງລັດ Terminal ຢູ່ມຸມຂວາລຸ່ມຂອງໜ້າ.',
+        showTerminalButton: 'ທາງລັດ Terminal',
+        showTerminalButtonHelper: 'ເມື່ອເປີດໃຊ້ງານ ປຸ່ມທາງລັດ Terminal ຈະປາກົດຢູ່ມຸມຂວາລຸ່ມຂອງໜ້າ.',
         local: 'ພາຍໃນເຄື່ອງ (Local)',
         defaultConn: 'ການເຊື່ອມຕໍ່ເລີ່ມຕົ້ນ',
         defaultConnHelper:

--- a/frontend/src/lang/modules/ms.ts
+++ b/frontend/src/lang/modules/ms.ts
@@ -2095,8 +2095,9 @@ const message = {
         profileBlockDesc: 'Mengukur sekatan pada Channel, Select dan primitif penyegerakan.',
     },
     terminal: {
-        showTerminalButton: 'Papar Butang Terminal',
-        showTerminalButtonHelper: 'Paparkan butang pintasan terminal di sudut kanan bawah halaman.',
+        showTerminalButton: 'Pintasan Terminal',
+        showTerminalButtonHelper:
+            'Apabila diaktifkan, butang pintasan terminal akan dipaparkan di sudut kanan bawah halaman.',
         local: 'Tempatan',
         defaultConn: 'Sambungan Lalai',
         defaultConnHelper:

--- a/frontend/src/lang/modules/pt-br.ts
+++ b/frontend/src/lang/modules/pt-br.ts
@@ -2100,8 +2100,9 @@ const message = {
         profileBlockDesc: 'Mede bloqueios em canais, select e primitivas de sincronização.',
     },
     terminal: {
-        showTerminalButton: 'Mostrar botão do terminal',
-        showTerminalButtonHelper: 'Mostrar o botão de acesso ao terminal no canto inferior direito da página.',
+        showTerminalButton: 'Atalho para o terminal',
+        showTerminalButtonHelper:
+            'Ao ativar esta opção, um botão de atalho para o terminal será exibido no canto inferior direito da página.',
         local: 'Local',
         defaultConn: 'Conexão Padrão',
         defaultConnHelper:

--- a/frontend/src/lang/modules/ru.ts
+++ b/frontend/src/lang/modules/ru.ts
@@ -2081,8 +2081,9 @@ const message = {
         profileBlockDesc: 'Измеряет блокировки на каналах, select и примитивах синхронизации.',
     },
     terminal: {
-        showTerminalButton: 'Показывать кнопку терминала',
-        showTerminalButtonHelper: 'Показывать кнопку быстрого доступа к терминалу в правом нижнем углу страницы.',
+        showTerminalButton: 'Быстрый доступ к терминалу',
+        showTerminalButtonHelper:
+            'При включении в правом нижнем углу страницы отображается кнопка быстрого доступа к терминалу.',
         local: 'Локальный',
         defaultConn: 'Соединение по умолчанию',
         defaultConnHelper:

--- a/frontend/src/lang/modules/tr.ts
+++ b/frontend/src/lang/modules/tr.ts
@@ -2087,8 +2087,9 @@ const message = {
         profileBlockDesc: 'Channel, select ve eşzamanlama araçlarındaki engelleme süresini ölçer.',
     },
     terminal: {
-        showTerminalButton: 'Terminal düğmesini göster',
-        showTerminalButtonHelper: 'Sayfanın sağ alt köşesinde terminal kısayol düğmesini gösterir.',
+        showTerminalButton: 'Terminal kısayolu',
+        showTerminalButtonHelper:
+            'Etkinleştirildiğinde, sayfanın sağ alt köşesinde terminal kısayol düğmesi görüntülenir.',
         local: 'Yerel',
         defaultConn: 'Varsayılan Bağlantı',
         defaultConnHelper:

--- a/frontend/src/lang/modules/zh-Hant.ts
+++ b/frontend/src/lang/modules/zh-Hant.ts
@@ -1954,8 +1954,8 @@ const message = {
         profileBlockDesc: '統計 Channel、Select 和同步原語的阻塞等待，用於定位長時間阻塞。',
     },
     terminal: {
-        showTerminalButton: '顯示終端按鈕',
-        showTerminalButtonHelper: '在頁面右下角顯示終端快捷按鈕。',
+        showTerminalButton: '終端捷徑',
+        showTerminalButtonHelper: '啟用後，頁面右下角會顯示終端捷徑按鈕。',
         local: '本機',
         defaultConn: '預設連接',
         defaultConnHelper: '該操作將【{0}】開啟終端後自動連線到所在節點終端，是否繼續？',

--- a/frontend/src/lang/modules/zh.ts
+++ b/frontend/src/lang/modules/zh.ts
@@ -1984,8 +1984,8 @@ const message = {
         profileBlockDesc: '统计 Channel、Select 和同步原语的阻塞等待，用于定位长时间阻塞。',
     },
     terminal: {
-        showTerminalButton: '显示终端按钮',
-        showTerminalButtonHelper: '在页面右下角显示终端快捷按钮。',
+        showTerminalButton: '终端快捷入口',
+        showTerminalButtonHelper: '开启后，将在页面右下角显示终端快捷按钮。',
         local: '本机',
         defaultConn: '默认连接',
         defaultConnHelper: '该操作将【{0}】打开终端后自动连接所在节点终端，是否继续？',


### PR DESCRIPTION
#### What this PR does / why we need it?

将终端设置项名称调整为“终端快捷入口”，提示调整为“开启后，将在页面右下角显示终端快捷按钮。”，明确开关用途及开启后的显示位置。

#### Summary of your change

- 同步调整全部 12 个语言文件，按各语言的使用习惯表达快捷入口及启用提示。
- 每个语言文件仅修改 `terminal.showTerminalButton` 和 `terminal.showTerminalButtonHelper` 两条文案，沿用现有语言键及交互逻辑。

验证：
- 12 个语言文件的 Prettier、ESLint、TypeScript 语法检查及 `git diff --check` 通过。
- 多语言文件独立 Vite 生产构建、压缩及加载通过，24 条修改后的文案完整保留。
- 全量 `npm run build:pro` 在本地依赖环境中无法解析文件历史编辑器的 `monaco-editor/editor` 导入；本地安装版本为 `0.53.0`，项目声明为 `^0.56.0`。在临时副本中恢复本次修改前的 12 个语言文件后，对照构建仍报相同错误。

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.（本次修改的专项检查通过；全量构建受上述现有问题阻塞。）
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.（文案调整，无需单独更新文档。）
